### PR TITLE
feat: support limit to last feature

### DIFF
--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -272,6 +272,24 @@ class CollectionReference(object):
         query = query_mod.Query(self)
         return query.limit(count)
 
+    def limit_to_last(self, count):
+        """Create a limited query with this collection as parent.
+
+        See
+        :meth:`~google.cloud.firestore_v1.query.Query.limit` for
+        more information on this method.
+
+        Args:
+            count (int): Maximum number of documents to return that match
+                the query.
+
+        Returns:
+            :class:`~google.cloud.firestore_v1.query.Query`:
+            A limited query.
+        """
+        query = query_mod.Query(self)
+        return query.limit_to_last(count)
+
     def offset(self, num_to_skip):
         """Skip to an offset in a query with this collection as parent.
 

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -14,7 +14,6 @@
 
 """Classes for representing collections for the Google Cloud Firestore API."""
 import random
-import warnings
 
 import six
 
@@ -273,19 +272,19 @@ class CollectionReference(object):
         return query.limit(count)
 
     def limit_to_last(self, count):
-        """Create a limited query with this collection as parent.
+        """Create a limited to last query with this collection as parent.
 
         See
         :meth:`~google.cloud.firestore_v1.query.Query.limit` for
         more information on this method.
 
         Args:
-            count (int): Maximum number of documents to return that match
-                the query.
+            count (int): Maximum number of documents to return that
+                match the query.
 
         Returns:
             :class:`~google.cloud.firestore_v1.query.Query`:
-            A limited query.
+            A limited to last query.
         """
         query = query_mod.Query(self)
         return query.limit_to_last(count)
@@ -393,13 +392,25 @@ class CollectionReference(object):
         return query.end_at(document_fields)
 
     def get(self, transaction=None):
-        """Deprecated alias for :meth:`stream`."""
-        warnings.warn(
-            "'Collection.get' is deprecated:  please use 'Collection.stream' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.stream(transaction=transaction)
+        """Read the documents in this collection.
+
+        This sends a ``RunQuery`` RPC and returns a list of documents
+        returned in the stream of ``RunQueryResponse`` messages.
+
+        Args:
+            transaction
+                (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+                An existing transaction that this query will run in.
+
+        If a ``transaction`` is used and it already has write operations
+        added, this method cannot be used (i.e. read-after-write is not
+        allowed).
+
+        Returns:
+            list: The documents in the collection that match this query.
+        """
+        query = query_mod.Query(self)
+        return query.get(transaction=transaction)
 
     def stream(self, transaction=None):
         """Read the documents in this collection.

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -256,6 +256,11 @@ class CollectionReference(object):
     def limit(self, count):
         """Create a limited query with this collection as parent.
 
+        .. note::
+
+           `limit` and `limit_to_last` are mutually exclusive.
+           Setting `limit` will drop previously set `limit_to_last`.
+
         See
         :meth:`~google.cloud.firestore_v1.query.Query.limit` for
         more information on this method.
@@ -273,6 +278,11 @@ class CollectionReference(object):
 
     def limit_to_last(self, count):
         """Create a limited to last query with this collection as parent.
+
+        .. note::
+
+           `limit` and `limit_to_last` are mutually exclusive.
+           Setting `limit_to_last` will drop previously set `limit`.
 
         See
         :meth:`~google.cloud.firestore_v1.query.Query.limit_to_last`

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -275,8 +275,8 @@ class CollectionReference(object):
         """Create a limited to last query with this collection as parent.
 
         See
-        :meth:`~google.cloud.firestore_v1.query.Query.limit` for
-        more information on this method.
+        :meth:`~google.cloud.firestore_v1.query.Query.limit_to_last`
+        for more information on this method.
 
         Args:
             count (int): Maximum number of documents to return that
@@ -407,7 +407,7 @@ class CollectionReference(object):
         allowed).
 
         Returns:
-            list: The documents in the collection that match this query.
+            list: The documents in this collection that match the query.
         """
         query = query_mod.Query(self)
         return query.get(transaction=transaction)

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -351,6 +351,11 @@ class Query(object):
 
         If the current query already has a `limit` set, this will override it.
 
+        .. note::
+
+           `limit` and `limit_to_last` are mutually exclusive.
+           Setting `limit` will drop previously set `limit_to_last`.
+
         Args:
             count (int): Maximum number of documents to return that match
                 the query.
@@ -378,6 +383,11 @@ class Query(object):
 
         If the current query already has a `limit_to_last`
         set, this will override it.
+
+        .. note::
+
+           `limit` and `limit_to_last` are mutually exclusive.
+           Setting `limit_to_last` will drop previously set `limit`.
 
         Args:
             count (int): Maximum number of documents to return that match
@@ -786,10 +796,9 @@ class Query(object):
         is_limited_to_last = self._limit_to_last
 
         if self._limit_to_last:
-            # In order to fetch up to `self._limit` results from the end of the 
-            # query flip the defined ordering on the query to start from the 
+            # In order to fetch up to `self._limit` results from the end of the
+            # query flip the defined ordering on the query to start from the
             # end, retrieving up to `self._limit` results from the backend.
-
             for order in self._orders:
                 order.direction = _enum_from_direction(
                     self.DESCENDING

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -347,7 +347,7 @@ class Query(object):
     def limit(self, count):
         """Limit a query to return first `count` results.
 
-        If the current query already has a limit set, this will overwrite it.
+        If the current query already has a `limit` set, this will overwrite it.
 
         Args:
             count (int): Maximum number of documents to return that match
@@ -373,7 +373,8 @@ class Query(object):
     def limit_to_last(self, count):
         """Limit a query to return last `count` results.
 
-        If the current query already has a limit set, this will overwrite it.
+        If the current query already has a `limit_to_last`
+        set, this will overwrite it.
 
         Args:
             count (int): Maximum number of documents to return that match
@@ -778,10 +779,10 @@ class Query(object):
         Returns:
             list: The documents in the collection that match this query.
         """
-        is_limit_to_last = False
+        is_limited_to_last = False
 
         if self._limit_to_last is not None:
-            is_limit_to_last = True
+            is_limited_to_last = True
             self._limit = self._limit_to_last
             self._limit_to_last = None
 
@@ -794,7 +795,7 @@ class Query(object):
                 )
 
         result = self.stream(transaction=transaction)
-        if is_limit_to_last:
+        if is_limited_to_last:
             result = reversed(list(result))
 
         return list(result)

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -347,7 +347,7 @@ class Query(object):
         )
 
     def limit(self, count):
-        """Limit a query to return the next `count` matching results.
+        """Limit a query to return at most `count` matching results.
 
         If the current query already has a `limit` set, this will override it.
 
@@ -786,7 +786,10 @@ class Query(object):
         is_limited_to_last = self._limit_to_last
 
         if self._limit_to_last:
-            # flip order statements
+            # In order to fetch up to `self._limit` results from the end of the 
+            # query flip the defined ordering on the query to start from the 
+            # end, retrieving up to `self._limit` results from the backend.
+
             for order in self._orders:
                 order.direction = _enum_from_direction(
                     self.DESCENDING

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -778,7 +778,10 @@ class Query(object):
         Returns:
             list: The documents in the collection that match this query.
         """
+        is_limit_to_last = False
+
         if self._limit_to_last is not None:
+            is_limit_to_last = True
             self._limit = self._limit_to_last
             self._limit_to_last = None
 
@@ -790,8 +793,11 @@ class Query(object):
                     else self.ASCENDING
                 )
 
-        result = list(self.stream(transaction=transaction))
-        return list(reversed(result))
+        result = self.stream(transaction=transaction)
+        if is_limit_to_last:
+            result = reversed(list(result))
+
+        return list(result)
 
     def stream(self, transaction=None):
         """Read the documents in the collection that match this query.

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -347,9 +347,9 @@ class Query(object):
         )
 
     def limit(self, count):
-        """Limit a query to return first `count` results.
+        """Limit a query to return the first `count` matching results.
 
-        If the current query already has a `limit` set, this will overwrite it.
+        If the current query already has a `limit` set, this will override it.
 
         Args:
             count (int): Maximum number of documents to return that match
@@ -374,10 +374,10 @@ class Query(object):
         )
 
     def limit_to_last(self, count):
-        """Limit a query to return last `count` results.
+        """Limit a query to return the last `count` matching results.
 
         If the current query already has a `limit_to_last`
-        set, this will overwrite it.
+        set, this will override it.
 
         Args:
             count (int): Maximum number of documents to return that match

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -86,7 +86,7 @@ class Query(object):
         limit (Optional[int]):
             The maximum number of documents the query is allowed to return.
         limit_to_last (Optional[bool]):
-            Limit query results to last.
+            Denotes whether a provided limit is applied to the end of the result set.
         offset (Optional[int]):
             The number of results to skip.
         start_at (Optional[Tuple[dict, bool]]):
@@ -347,7 +347,7 @@ class Query(object):
         )
 
     def limit(self, count):
-        """Limit a query to return the first `count` matching results.
+        """Limit a query to return the next `count` matching results.
 
         If the current query already has a `limit` set, this will override it.
 

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -371,6 +371,17 @@ class TestCollectionReference(unittest.TestCase):
         self.assertIs(query._parent, collection)
         self.assertEqual(query._limit, limit)
 
+    def test_limit_to_last(self):
+        from google.cloud.firestore_v1.query import Query
+
+        collection = self._make_one("collection")
+        LIMIT = 15
+        query = collection.limit_to_last(LIMIT)
+
+        self.assertIsInstance(query, Query)
+        self.assertIs(query._parent, collection)
+        self.assertEqual(query._limit_to_last, LIMIT)
+
     def test_offset(self):
         from google.cloud.firestore_v1.query import Query
 
@@ -484,38 +495,26 @@ class TestCollectionReference(unittest.TestCase):
 
     @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
     def test_get(self, query_class):
-        import warnings
-
         collection = self._make_one("collection")
-        with warnings.catch_warnings(record=True) as warned:
-            get_response = collection.get()
+        get_response = collection.get()
 
         query_class.assert_called_once_with(collection)
         query_instance = query_class.return_value
-        self.assertIs(get_response, query_instance.stream.return_value)
-        query_instance.stream.assert_called_once_with(transaction=None)
 
-        # Verify the deprecation
-        self.assertEqual(len(warned), 1)
-        self.assertIs(warned[0].category, DeprecationWarning)
+        self.assertIs(get_response, query_instance.get.return_value)
+        query_instance.get.assert_called_once_with(transaction=None)
 
     @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
     def test_get_with_transaction(self, query_class):
-        import warnings
-
         collection = self._make_one("collection")
         transaction = mock.sentinel.txn
-        with warnings.catch_warnings(record=True) as warned:
-            get_response = collection.get(transaction=transaction)
+        get_response = collection.get(transaction=transaction)
 
         query_class.assert_called_once_with(collection)
         query_instance = query_class.return_value
-        self.assertIs(get_response, query_instance.stream.return_value)
-        query_instance.stream.assert_called_once_with(transaction=transaction)
 
-        # Verify the deprecation
-        self.assertEqual(len(warned), 1)
-        self.assertIs(warned[0].category, DeprecationWarning)
+        self.assertIs(get_response, query_instance.get.return_value)
+        query_instance.get.assert_called_once_with(transaction=transaction)
 
     @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
     def test_stream(self, query_class):

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -374,13 +374,14 @@ class TestCollectionReference(unittest.TestCase):
     def test_limit_to_last(self):
         from google.cloud.firestore_v1.query import Query
 
-        collection = self._make_one("collection")
         LIMIT = 15
+        collection = self._make_one("collection")
         query = collection.limit_to_last(LIMIT)
 
         self.assertIsInstance(query, Query)
         self.assertIs(query._parent, collection)
-        self.assertEqual(query._limit_to_last, LIMIT)
+        self.assertEqual(query._limit, LIMIT)
+        self.assertTrue(query._limit_to_last)
 
     def test_offset(self):
         from google.cloud.firestore_v1.query import Query

--- a/tests/unit/v1/test_query.py
+++ b/tests/unit/v1/test_query.py
@@ -1077,12 +1077,10 @@ class TestQuery(unittest.TestCase):
         _, expected_prefix = parent._parent_info()
         name = "{}/sleep".format(expected_prefix)
         data = {"snooze": 10}
-        data2 = {"snooze": 20}
 
         response_pb = _make_query_response(name=name, data=data)
-        response_pb2 = _make_query_response(name=name, data=data2)
 
-        firestore_api.run_query.return_value = iter([response_pb, response_pb2])
+        firestore_api.run_query.return_value = iter([response_pb])
 
         # Execute the query and check the response.
         query = self._make_one(parent)
@@ -1090,15 +1088,11 @@ class TestQuery(unittest.TestCase):
 
         self.assertIsInstance(get_response, list)
         returned = list(get_response)
-        self.assertEqual(len(returned), 2)
+        self.assertEqual(len(returned), 1)
 
         snapshot = returned[0]
         self.assertEqual(snapshot.reference._path, ("dee", "sleep"))
-        self.assertEqual(snapshot.to_dict(), data2)
-
-        snapshot2 = returned[1]
-        self.assertEqual(snapshot2.reference._path, ("dee", "sleep"))
-        self.assertEqual(snapshot2.to_dict(), data)
+        self.assertEqual(snapshot.to_dict(), data)
 
         # Verify the mock call.
         parent_path, _ = parent._parent_info()

--- a/tests/unit/v1/test_query.py
+++ b/tests/unit/v1/test_query.py
@@ -1136,7 +1136,7 @@ class TestQuery(unittest.TestCase):
 
         self.assertIsInstance(returned, list)
         self.assertEqual(
-            query._orders[0].direction, _enum_from_direction(firestore.Query.ASCENDING),
+            query._orders[0].direction, _enum_from_direction(firestore.Query.ASCENDING)
         )
         self.assertEqual(len(returned), 2)
 

--- a/tests/unit/v1/test_query.py
+++ b/tests/unit/v1/test_query.py
@@ -1084,10 +1084,9 @@ class TestQuery(unittest.TestCase):
 
         # Execute the query and check the response.
         query = self._make_one(parent)
-        get_response = query.get()
+        returned = query.get()
 
-        self.assertIsInstance(get_response, list)
-        returned = list(get_response)
+        self.assertIsInstance(returned, list)
         self.assertEqual(len(returned), 1)
 
         snapshot = returned[0]
@@ -1191,6 +1190,20 @@ class TestQuery(unittest.TestCase):
             transaction=None,
             metadata=client._rpc_metadata,
         )
+
+    def test_stream_with_limit_to_last(self):
+        # Attach the fake GAPIC to a real client.
+        client = _make_client()
+        # Make a **real** collection reference as parent.
+        parent = client.collection("dee")
+        # Execute the query and check the response.
+        query = self._make_one(parent)
+        query = query.limit_to_last(2)
+
+        stream_response = query.stream()
+
+        with self.assertRaises(ValueError):
+            list(stream_response)
 
     def test_stream_with_transaction(self):
         # Create a minimal fake GAPIC.


### PR DESCRIPTION
Pushing an implementation with de-deprecation of the `get()` method (as @BenWhitehead mentioned).