### PR TITLE
fix: Python requires didn't exclude 3.4 to match classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
         "Topic :: Internet",
     ],
@@ -79,7 +80,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
commit 48339ec removed the 3.4 classifier, but requires wasn't updated.

We could consider this breaking as it will prevent installs. We could also hold this until we drop 3.5, likely September.
