### PR TITLE
fix: pytype client errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pip-log.txt
 .nox
 .cache
 .pytest_cache
+.pytype
 
 
 # Mac

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -25,8 +25,8 @@ In the hierarchy of API concepts
 """
 import os
 
-import google.api_core.client_options
-import google.api_core.path_template
+import google.api_core.client_options  # type: ignore
+import google.api_core.path_template  # type: ignore
 from google.api_core.gapic_v1 import client_info  # type: ignore
 from google.cloud.client import ClientWithProject  # type: ignore
 


### PR DESCRIPTION
Adds pytype to gitignore and fixes the following:

```
[47/63] check base_client
FAILED: /home/rafilong/workspace/googleapis/python-firestore/.pytype/pyi/base_client.pyi 
/home/rafilong/workspace/googleapis/python-firestore/.nox/pytype/bin/python -m pytype.single --disable pyi-error --imports_info /home/rafilong/workspace/googleapis/python-firestore/.pytype/imports/base_client.imports --module-name base_client -V 3.8 -o /home/rafilong/workspace/googleapis/python-firestore/.pytype/pyi/base_client.pyi --analyze-annotated --nofail --quick /home/rafilong/workspace/googleapis/python-firestore/google/cloud/firestore_v1/__pycache__/base_client.py
File "/home/rafilong/workspace/googleapis/python-firestore/google/cloud/firestore_v1/__pycache__/base_client.py", line 37, in <module>: Can't find module 'google.cloud.firestore_v1.gapic'. [import-error]
File "/home/rafilong/workspace/googleapis/python-firestore/google/cloud/firestore_v1/__pycache__/base_client.py", line 38, in <module>: Can't find module 'google.cloud.firestore_v1.gapic.transports'. [import-error]
```