### PR TITLE
feat: use 'update_transforms'

### DIFF
--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -495,7 +495,9 @@ class DocumentExtractor(object):
 
         return update_pb
 
-    def get_transform_pb(self, document_path, exists=None) -> types.write.Write:
+    def get_field_transform_pbs(
+        self, document_path
+    ) -> List[types.write.DocumentTransform.FieldTransform]:
         def make_array_value(values):
             value_list = [encode_value(element) for element in values]
             return document.ArrayValue(values=value_list)
@@ -559,9 +561,10 @@ class DocumentExtractor(object):
                 for path, value in self.minimums.items()
             ]
         )
-        field_transforms = [
-            transform for path, transform in sorted(path_field_transforms)
-        ]
+        return [transform for path, transform in sorted(path_field_transforms)]
+
+    def get_transform_pb(self, document_path, exists=None) -> types.write.Write:
+        field_transforms = self.get_field_transform_pbs(document_path)
         transform_pb = write.Write(
             transform=write.DocumentTransform(
                 document=document_path, field_transforms=field_transforms
@@ -592,19 +595,13 @@ def pbs_for_create(document_path, document_data) -> List[types.write.Write]:
     if extractor.deleted_fields:
         raise ValueError("Cannot apply DELETE_FIELD in a create request.")
 
-    write_pbs = []
-
-    # Conformance tests require skipping the 'update_pb' if the document
-    # contains only transforms.
-    if extractor.empty_document or extractor.set_fields:
-        write_pbs.append(extractor.get_update_pb(document_path, exists=False))
+    create_pb = extractor.get_update_pb(document_path, exists=False)
 
     if extractor.has_transforms:
-        exists = None if write_pbs else False
-        transform_pb = extractor.get_transform_pb(document_path, exists)
-        write_pbs.append(transform_pb)
+        field_transform_pbs = extractor.get_field_transform_pbs(document_path)
+        create_pb.update_transforms.extend(field_transform_pbs)
 
-    return write_pbs
+    return [create_pb]
 
 
 def pbs_for_set_no_merge(document_path, document_data) -> List[types.write.Write]:

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -794,19 +794,14 @@ def pbs_for_set_with_merge(
     extractor.apply_merge(merge)
 
     merge_empty = not document_data
+    allow_empty_mask = merge_empty or extractor.transform_paths
 
-    write_pbs = []
-
-    if extractor.has_updates or merge_empty:
-        write_pbs.append(
-            extractor.get_update_pb(document_path, allow_empty_mask=merge_empty)
-        )
-
+    set_pb = extractor.get_update_pb(document_path, allow_empty_mask=allow_empty_mask)
     if extractor.transform_paths:
-        transform_pb = extractor.get_transform_pb(document_path)
-        write_pbs.append(transform_pb)
+        field_transform_pbs = extractor.get_field_transform_pbs(document_path)
+        set_pb.update_transforms.extend(field_transform_pbs)
 
-    return write_pbs
+    return [set_pb]
 
 
 class DocumentExtractorForUpdate(DocumentExtractor):

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -624,15 +624,13 @@ def pbs_for_set_no_merge(document_path, document_data) -> List[types.write.Write
             "specifying 'merge=True' or 'merge=[field_paths]'."
         )
 
-    # Conformance tests require send the 'update_pb' even if the document
-    # contains only transforms.
-    write_pbs = [extractor.get_update_pb(document_path)]
+    set_pb = extractor.get_update_pb(document_path)
 
     if extractor.has_transforms:
-        transform_pb = extractor.get_transform_pb(document_path)
-        write_pbs.append(transform_pb)
+        field_transform_pbs = extractor.get_field_transform_pbs(document_path)
+        set_pb.update_transforms.extend(field_transform_pbs)
 
-    return write_pbs
+    return [set_pb]
 
 
 class DocumentExtractorForMerge(DocumentExtractor):

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -866,22 +866,14 @@ def pbs_for_update(document_path, field_updates, option) -> List[types.write.Wri
     if option is None:  # Default is to use ``exists=True``.
         option = ExistsOption(exists=True)
 
-    write_pbs = []
-
-    if extractor.field_paths or extractor.deleted_fields:
-        update_pb = extractor.get_update_pb(document_path)
-        option.modify_write(update_pb)
-        write_pbs.append(update_pb)
+    update_pb = extractor.get_update_pb(document_path)
+    option.modify_write(update_pb)
 
     if extractor.has_transforms:
-        transform_pb = extractor.get_transform_pb(document_path)
-        if not write_pbs:
-            # NOTE: set the write option on the ``transform_pb`` only if there
-            #       is no ``update_pb``
-            option.modify_write(transform_pb)
-        write_pbs.append(transform_pb)
+        field_transform_pbs = extractor.get_field_transform_pbs(document_path)
+        update_pb.update_transforms.extend(field_transform_pbs)
 
-    return write_pbs
+    return [update_pb]
 
 
 def pb_for_delete(document_path, option) -> types.write.Write:

--- a/tests/unit/v1/test__helpers.py
+++ b/tests/unit/v1/test__helpers.py
@@ -2159,23 +2159,19 @@ class Test_pbs_for_update(unittest.TestCase):
         if isinstance(option, _helpers.ExistsOption):
             precondition = common.Precondition(exists=False)
             expected_update_pb._pb.current_document.CopyFrom(precondition._pb)
-        expected_pbs = [expected_update_pb]
+
         if do_transform:
             transform_paths = FieldPath.from_string(field_path2)
             server_val = DocumentTransform.FieldTransform.ServerValue
-            expected_transform_pb = write.Write(
-                transform=write.DocumentTransform(
-                    document=document_path,
-                    field_transforms=[
-                        write.DocumentTransform.FieldTransform(
-                            field_path=transform_paths.to_api_repr(),
-                            set_to_server_value=server_val.REQUEST_TIME,
-                        )
-                    ],
+            field_transform_pbs = [
+                write.DocumentTransform.FieldTransform(
+                    field_path=transform_paths.to_api_repr(),
+                    set_to_server_value=server_val.REQUEST_TIME,
                 )
-            )
-            expected_pbs.append(expected_transform_pb)
-        self.assertEqual(write_pbs, expected_pbs)
+            ]
+            expected_update_pb.update_transforms.extend(field_transform_pbs)
+
+        self.assertEqual(write_pbs, [expected_update_pb])
 
     def test_without_option(self):
         from google.cloud.firestore_v1.types import common

--- a/tests/unit/v1/test__helpers.py
+++ b/tests/unit/v1/test__helpers.py
@@ -1271,10 +1271,6 @@ class TestDocumentExtractor(unittest.TestCase):
         self.assertFalse(update_pb._pb.HasField("current_document"))
 
     def test_get_field_transform_pbs_miss(self):
-        from google.cloud.firestore_v1.types import write
-        from google.cloud.firestore_v1.transforms import SERVER_TIMESTAMP
-        from google.cloud.firestore_v1._helpers import REQUEST_TIME_ENUM
-
         document_data = {"a": 1}
         inst = self._make_one(document_data)
         document_path = (
@@ -1563,7 +1559,6 @@ class Test_pbs_for_create(unittest.TestCase):
 
     @staticmethod
     def _add_field_transforms(update_pb, fields):
-        from google.cloud.firestore_v1.types import write
         from google.cloud.firestore_v1 import DocumentTransform
 
         server_val = DocumentTransform.FieldTransform.ServerValue
@@ -1632,7 +1627,6 @@ class Test_pbs_for_set_no_merge(unittest.TestCase):
 
     @staticmethod
     def _add_field_transforms(update_pb, fields):
-        from google.cloud.firestore_v1.types import write
         from google.cloud.firestore_v1 import DocumentTransform
 
         server_val = DocumentTransform.FieldTransform.ServerValue
@@ -1925,7 +1919,6 @@ class Test_pbs_for_set_with_merge(unittest.TestCase):
 
     @staticmethod
     def _add_field_transforms(update_pb, fields):
-        from google.cloud.firestore_v1.types import write
         from google.cloud.firestore_v1 import DocumentTransform
 
         server_val = DocumentTransform.FieldTransform.ServerValue

--- a/tests/unit/v1/testdata/create-all-transforms.json
+++ b/tests/unit/v1/testdata/create-all-transforms.json
@@ -20,50 +20,45 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-arrayremove-multi.json
+++ b/tests/unit/v1/testdata/create-arrayremove-multi.json
@@ -20,46 +20,41 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-arrayremove-nested.json
+++ b/tests/unit/v1/testdata/create-arrayremove-nested.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-arrayremove.json
+++ b/tests/unit/v1/testdata/create-arrayremove.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-arrayunion-multi.json
+++ b/tests/unit/v1/testdata/create-arrayunion-multi.json
@@ -20,46 +20,41 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-arrayunion-nested.json
+++ b/tests/unit/v1/testdata/create-arrayunion-nested.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-arrayunion.json
+++ b/tests/unit/v1/testdata/create-arrayunion.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-st-alone.json
+++ b/tests/unit/v1/testdata/create-st-alone.json
@@ -10,18 +10,19 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": false
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-st-multi.json
+++ b/tests/unit/v1/testdata/create-st-multi.json
@@ -20,22 +20,17 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-st-nested.json
+++ b/tests/unit/v1/testdata/create-st-nested.json
@@ -20,18 +20,13 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-st-with-empty-map.json
+++ b/tests/unit/v1/testdata/create-st-with-empty-map.json
@@ -28,18 +28,13 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/create-st.json
+++ b/tests/unit/v1/testdata/create-st.json
@@ -20,18 +20,13 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-all-transforms.json
+++ b/tests/unit/v1/testdata/set-all-transforms.json
@@ -17,50 +17,45 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-arrayremove-multi.json
+++ b/tests/unit/v1/testdata/set-arrayremove-multi.json
@@ -17,46 +17,41 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-arrayremove-nested.json
+++ b/tests/unit/v1/testdata/set-arrayremove-nested.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-arrayremove.json
+++ b/tests/unit/v1/testdata/set-arrayremove.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-arrayunion-multi.json
+++ b/tests/unit/v1/testdata/set-arrayunion-multi.json
@@ -17,46 +17,41 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-arrayunion-nested.json
+++ b/tests/unit/v1/testdata/set-arrayunion-nested.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-arrayunion.json
+++ b/tests/unit/v1/testdata/set-arrayunion.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-alone-mergeall.json
+++ b/tests/unit/v1/testdata/set-st-alone-mergeall.json
@@ -13,15 +13,19 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-alone.json
+++ b/tests/unit/v1/testdata/set-st-alone.json
@@ -13,18 +13,13 @@
               "update": {
                 "name": "projects/projectID/databases/(default)/documents/C/d",
                 "fields": {}
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-merge-both.json
+++ b/tests/unit/v1/testdata/set-st-merge-both.json
@@ -36,18 +36,13 @@
                 "fieldPaths": [
                   "a"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-merge-nonleaf-alone.json
+++ b/tests/unit/v1/testdata/set-st-merge-nonleaf-alone.json
@@ -26,18 +26,13 @@
                 "fieldPaths": [
                   "h"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "h.g",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "h.g",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-merge-nonleaf.json
+++ b/tests/unit/v1/testdata/set-st-merge-nonleaf.json
@@ -37,18 +37,13 @@
                 "fieldPaths": [
                   "h"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "h.g",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "h.g",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-merge-nowrite.json
+++ b/tests/unit/v1/testdata/set-st-merge-nowrite.json
@@ -19,15 +19,19 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-mergeall.json
+++ b/tests/unit/v1/testdata/set-st-mergeall.json
@@ -25,18 +25,13 @@
                 "fieldPaths": [
                   "a"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-multi.json
+++ b/tests/unit/v1/testdata/set-st-multi.json
@@ -17,22 +17,17 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-nested.json
+++ b/tests/unit/v1/testdata/set-st-nested.json
@@ -17,18 +17,13 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st-with-empty-map.json
+++ b/tests/unit/v1/testdata/set-st-with-empty-map.json
@@ -25,18 +25,13 @@
                     }
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/set-st.json
+++ b/tests/unit/v1/testdata/set-st.json
@@ -17,18 +17,13 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-all-transforms.json
+++ b/tests/unit/v1/testdata/update-all-transforms.json
@@ -25,50 +25,45 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayremove-alone.json
+++ b/tests/unit/v1/testdata/update-arrayremove-alone.json
@@ -10,31 +10,35 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
-            }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }  
           ]
         }
       }

--- a/tests/unit/v1/testdata/update-arrayremove-multi.json
+++ b/tests/unit/v1/testdata/update-arrayremove-multi.json
@@ -26,46 +26,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayremove-nested.json
+++ b/tests/unit/v1/testdata/update-arrayremove-nested.json
@@ -26,30 +26,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayremove.json
+++ b/tests/unit/v1/testdata/update-arrayremove.json
@@ -25,30 +25,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayunion-alone.json
+++ b/tests/unit/v1/testdata/update-arrayunion-alone.json
@@ -10,30 +10,34 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  },
+                  "fieldPath": "a"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayunion-multi.json
+++ b/tests/unit/v1/testdata/update-arrayunion-multi.json
@@ -26,46 +26,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayunion-nested.json
+++ b/tests/unit/v1/testdata/update-arrayunion-nested.json
@@ -26,30 +26,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-arrayunion.json
+++ b/tests/unit/v1/testdata/update-arrayunion.json
@@ -25,30 +25,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-nested-transform-and-nested-value.json
+++ b/tests/unit/v1/testdata/update-nested-transform-and-nested-value.json
@@ -31,18 +31,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-all-transforms.json
+++ b/tests/unit/v1/testdata/update-paths-all-transforms.json
@@ -52,50 +52,45 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayremove-alone.json
+++ b/tests/unit/v1/testdata/update-paths-arrayremove-alone.json
@@ -19,30 +19,34 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayremove-multi.json
+++ b/tests/unit/v1/testdata/update-paths-arrayremove-multi.json
@@ -47,46 +47,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayremove-nested.json
+++ b/tests/unit/v1/testdata/update-paths-arrayremove-nested.json
@@ -41,30 +41,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayremove.json
+++ b/tests/unit/v1/testdata/update-paths-arrayremove.json
@@ -40,30 +40,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayunion-alone.json
+++ b/tests/unit/v1/testdata/update-paths-arrayunion-alone.json
@@ -19,30 +19,34 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  },
+                  "fieldPath": "a"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayunion-multi.json
+++ b/tests/unit/v1/testdata/update-paths-arrayunion-multi.json
@@ -47,46 +47,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayunion-nested.json
+++ b/tests/unit/v1/testdata/update-paths-arrayunion-nested.json
@@ -41,30 +41,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-arrayunion.json
+++ b/tests/unit/v1/testdata/update-paths-arrayunion.json
@@ -40,30 +40,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-nested-transform-and-nested-value.json
+++ b/tests/unit/v1/testdata/update-paths-nested-transform-and-nested-value.json
@@ -48,18 +48,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-st-alone.json
+++ b/tests/unit/v1/testdata/update-paths-st-alone.json
@@ -19,18 +19,22 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-st-multi.json
+++ b/tests/unit/v1/testdata/update-paths-st-multi.json
@@ -47,22 +47,17 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-st-nested.json
+++ b/tests/unit/v1/testdata/update-paths-st-nested.json
@@ -41,18 +41,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-paths-st-with-empty-map.json
+++ b/tests/unit/v1/testdata/update-paths-st-with-empty-map.json
@@ -40,19 +40,14 @@
                   "a"
                 ]
               },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ],
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
               }
             }
           ]

--- a/tests/unit/v1/testdata/update-paths-st.json
+++ b/tests/unit/v1/testdata/update-paths-st.json
@@ -40,18 +40,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-st-alone.json
+++ b/tests/unit/v1/testdata/update-st-alone.json
@@ -10,18 +10,22 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-st-dot.json
+++ b/tests/unit/v1/testdata/update-st-dot.json
@@ -10,18 +10,22 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-st-multi.json
+++ b/tests/unit/v1/testdata/update-st-multi.json
@@ -26,22 +26,17 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-st-nested.json
+++ b/tests/unit/v1/testdata/update-st-nested.json
@@ -26,18 +26,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-st-with-empty-map.json
+++ b/tests/unit/v1/testdata/update-st-with-empty-map.json
@@ -33,18 +33,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/tests/unit/v1/testdata/update-st.json
+++ b/tests/unit/v1/testdata/update-st.json
@@ -25,18 +25,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
Update `pbs_for_create`, `pbs_for_set_no_merge`, `pbs_for_set_with_merge`, and `pbs_for_update` to match semantics expected by current versions of [conformance tests](https://github.com/googleapis/conformance-tests/commit/0bb8520e48c35b3e0dd45c328a1b38be35664b91):

- Rather than create separate `Write.transform` messages to hold field transforms, inline them as `update_transforms` in the main `Write.update` message (which will always be created now).

Copy in the current version of the conftest JSON files and verify.

Closes #217