### PR TITLE
feat: add retry/timeout to manual surface

### DIFF
--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -1042,3 +1042,16 @@ class ExistsOption(WriteOption):
         """
         current_doc = types.Precondition(exists=self._exists)
         write._pb.current_document.CopyFrom(current_doc._pb)
+
+
+def make_retry_timeout_kwargs(retry, timeout) -> dict:
+    """Helper fo API methods which take optional 'retry' / 'timeout' args."""
+    kwargs = {}
+
+    if retry is not None:
+        kwargs["retry"] = retry
+
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+
+    return kwargs

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -16,13 +16,14 @@
 
 import datetime
 
+from google.api_core.datetime_helpers import DatetimeWithNanoseconds  # type: ignore
+from google.api_core import gapic_v1  # type: ignore
 from google.protobuf import struct_pb2
 from google.type import latlng_pb2  # type: ignore
 import grpc  # type: ignore
 
 from google.cloud import exceptions  # type: ignore
 from google.cloud._helpers import _datetime_to_pb_timestamp  # type: ignore
-from google.api_core.datetime_helpers import DatetimeWithNanoseconds  # type: ignore
 from google.cloud.firestore_v1.types.write import DocumentTransform
 from google.cloud.firestore_v1 import transforms
 from google.cloud.firestore_v1 import types
@@ -1048,7 +1049,7 @@ def make_retry_timeout_kwargs(retry, timeout) -> dict:
     """Helper fo API methods which take optional 'retry' / 'timeout' args."""
     kwargs = {}
 
-    if retry is not None:
+    if retry is not gapic_v1.method.DEFAULT:
         kwargs["retry"] = retry
 
     if timeout is not None:

--- a/google/cloud/firestore_v1/async_batch.py
+++ b/google/cloud/firestore_v1/async_batch.py
@@ -15,6 +15,7 @@
 """Helpers for batch requests to the Google Cloud Firestore API."""
 
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_batch import BaseWriteBatch
@@ -35,7 +36,9 @@ class AsyncWriteBatch(BaseWriteBatch):
     def __init__(self, client) -> None:
         super(AsyncWriteBatch, self).__init__(client=client)
 
-    async def commit(self, retry: retries.Retry = None, timeout: float = None) -> list:
+    async def commit(
+        self, retry: retries.Retry = gapic_v1.method.DEFAULT, timeout: float = None,
+    ) -> list:
         """Commit the changes accumulated in this batch.
 
         Args:

--- a/google/cloud/firestore_v1/async_batch.py
+++ b/google/cloud/firestore_v1/async_batch.py
@@ -40,8 +40,9 @@ class AsyncWriteBatch(BaseWriteBatch):
 
         Args:
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:

--- a/google/cloud/firestore_v1/async_batch.py
+++ b/google/cloud/firestore_v1/async_batch.py
@@ -15,6 +15,8 @@
 """Helpers for batch requests to the Google Cloud Firestore API."""
 
 
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1.base_batch import BaseWriteBatch
 
 
@@ -33,8 +35,13 @@ class AsyncWriteBatch(BaseWriteBatch):
     def __init__(self, client) -> None:
         super(AsyncWriteBatch, self).__init__(client=client)
 
-    async def commit(self) -> list:
+    async def commit(self, retry: retries.Retry = None, timeout: float = None) -> list:
         """Commit the changes accumulated in this batch.
+
+        Args:
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:
@@ -42,18 +49,16 @@ class AsyncWriteBatch(BaseWriteBatch):
             in the same order as the changes were applied to this batch. A
             write result contains an ``update_time`` field.
         """
+        request, kwargs = self._prep_commit(retry, timeout)
+
         commit_response = await self._client._firestore_api.commit(
-            request={
-                "database": self._client._database_string,
-                "writes": self._write_pbs,
-                "transaction": None,
-            },
-            metadata=self._client._rpc_metadata,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
 
         self._write_pbs = []
         self.write_results = results = list(commit_response.write_results)
         self.commit_time = commit_response.commit_time
+
         return results
 
     async def __aenter__(self):

--- a/google/cloud/firestore_v1/async_client.py
+++ b/google/cloud/firestore_v1/async_client.py
@@ -24,17 +24,16 @@ In the hierarchy of API concepts
   :class:`~google.cloud.firestore_v1.async_document.AsyncDocumentReference`
 """
 
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1.base_client import (
     BaseClient,
     DEFAULT_DATABASE,
     _CLIENT_INFO,
-    _reference_info,  # type: ignore
     _parse_batch_get,  # type: ignore
-    _get_doc_mask,
     _path_helper,
 )
 
-from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1.async_query import AsyncCollectionGroup
 from google.cloud.firestore_v1.async_batch import AsyncWriteBatch
 from google.cloud.firestore_v1.async_collection import AsyncCollectionReference
@@ -208,7 +207,12 @@ class AsyncClient(BaseClient):
         )
 
     async def get_all(
-        self, references: list, field_paths: Iterable[str] = None, transaction=None,
+        self,
+        references: list,
+        field_paths: Iterable[str] = None,
+        transaction=None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> AsyncGenerator[DocumentSnapshot, Any]:
         """Retrieve a batch of documents.
 
@@ -239,48 +243,52 @@ class AsyncClient(BaseClient):
             transaction (Optional[:class:`~google.cloud.firestore_v1.async_transaction.AsyncTransaction`]):
                 An existing transaction that these ``references`` will be
                 retrieved in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.
         """
-        document_paths, reference_map = _reference_info(references)
-        mask = _get_doc_mask(field_paths)
+        request, reference_map, kwargs = self._prep_get_all(
+            references, field_paths, transaction, retry, timeout
+        )
+
         response_iterator = await self._firestore_api.batch_get_documents(
-            request={
-                "database": self._database_string,
-                "documents": document_paths,
-                "mask": mask,
-                "transaction": _helpers.get_transaction_id(transaction),
-            },
-            metadata=self._rpc_metadata,
+            request=request, metadata=self._rpc_metadata, **kwargs,
         )
 
         async for get_doc_response in response_iterator:
             yield _parse_batch_get(get_doc_response, reference_map, self)
 
-    async def collections(self) -> AsyncGenerator[AsyncCollectionReference, Any]:
+    async def collections(
+        self, retry: retries.Retry = None, timeout: float = None,
+    ) -> AsyncGenerator[AsyncCollectionReference, Any]:
         """List top-level collections of the client's database.
+
+        Args:
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.async_collection.AsyncCollectionReference`]:
                 iterator of subcollections of the current document.
         """
+        request, kwargs = self._prep_collections(retry, timeout)
         iterator = await self._firestore_api.list_collection_ids(
-            request={"parent": "{}/documents".format(self._database_string)},
-            metadata=self._rpc_metadata,
+            request=request, metadata=self._rpc_metadata, **kwargs,
         )
 
         while True:
             for i in iterator.collection_ids:
                 yield self.collection(i)
             if iterator.next_page_token:
+                next_request = request.copy()
+                next_request["page_token"] = iterator.next_page_token
                 iterator = await self._firestore_api.list_collection_ids(
-                    request={
-                        "parent": "{}/documents".format(self._database_string),
-                        "page_token": iterator.next_page_token,
-                    },
-                    metadata=self._rpc_metadata,
+                    request=next_request, metadata=self._rpc_metadata, **kwargs,
                 )
             else:
                 return

--- a/google/cloud/firestore_v1/async_client.py
+++ b/google/cloud/firestore_v1/async_client.py
@@ -24,6 +24,7 @@ In the hierarchy of API concepts
   :class:`~google.cloud.firestore_v1.async_document.AsyncDocumentReference`
 """
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_client import (
@@ -211,7 +212,7 @@ class AsyncClient(BaseClient):
         references: list,
         field_paths: Iterable[str] = None,
         transaction=None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> AsyncGenerator[DocumentSnapshot, Any]:
         """Retrieve a batch of documents.
@@ -264,7 +265,7 @@ class AsyncClient(BaseClient):
             yield _parse_batch_get(get_doc_response, reference_map, self)
 
     async def collections(
-        self, retry: retries.Retry = None, timeout: float = None,
+        self, retry: retries.Retry = gapic_v1.method.DEFAULT, timeout: float = None,
     ) -> AsyncGenerator[AsyncCollectionReference, Any]:
         """List top-level collections of the client's database.
 

--- a/google/cloud/firestore_v1/async_client.py
+++ b/google/cloud/firestore_v1/async_client.py
@@ -244,8 +244,9 @@ class AsyncClient(BaseClient):
                 An existing transaction that these ``references`` will be
                 retrieved in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
@@ -269,8 +270,9 @@ class AsyncClient(BaseClient):
 
         Args:
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.async_collection.AsyncCollectionReference`]:

--- a/google/cloud/firestore_v1/async_collection.py
+++ b/google/cloud/firestore_v1/async_collection.py
@@ -14,6 +14,7 @@
 
 """Classes for representing collections for the Google Cloud Firestore API."""
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_collection import (
@@ -75,7 +76,7 @@ class AsyncCollectionReference(BaseCollectionReference):
         self,
         document_data: dict,
         document_id: str = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Tuple[Any, Any]:
         """Create a document in the Firestore database with the provided data.
@@ -112,7 +113,10 @@ class AsyncCollectionReference(BaseCollectionReference):
         return write_result.update_time, document_ref
 
     async def list_documents(
-        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        page_size: int = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> AsyncGenerator[DocumentReference, None]:
         """List all subdocuments of the current collection.
 
@@ -142,7 +146,7 @@ class AsyncCollectionReference(BaseCollectionReference):
     async def get(
         self,
         transaction: Transaction = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> list:
         """Read the documents in this collection.
@@ -173,7 +177,7 @@ class AsyncCollectionReference(BaseCollectionReference):
     async def stream(
         self,
         transaction: Transaction = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> AsyncIterator[async_document.DocumentSnapshot]:
         """Read the documents in this collection.

--- a/google/cloud/firestore_v1/async_collection.py
+++ b/google/cloud/firestore_v1/async_collection.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 """Classes for representing collections for the Google Cloud Firestore API."""
+
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1.base_collection import (
     BaseCollectionReference,
-    _auto_id,
     _item_to_document_ref,
 )
 from google.cloud.firestore_v1 import (
@@ -70,7 +72,11 @@ class AsyncCollectionReference(BaseCollectionReference):
         return async_query.AsyncQuery(self)
 
     async def add(
-        self, document_data: dict, document_id: str = None
+        self,
+        document_data: dict,
+        document_id: str = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Tuple[Any, Any]:
         """Create a document in the Firestore database with the provided data.
 
@@ -82,6 +88,9 @@ class AsyncCollectionReference(BaseCollectionReference):
                 automatically assigned by the server (the assigned ID will be
                 a random 20 character string composed of digits,
                 uppercase and lowercase letters).
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Tuple[:class:`google.protobuf.timestamp_pb2.Timestamp`, \
@@ -95,22 +104,24 @@ class AsyncCollectionReference(BaseCollectionReference):
             ~google.cloud.exceptions.Conflict: If ``document_id`` is provided
                 and the document already exists.
         """
-        if document_id is None:
-            document_id = _auto_id()
-
-        document_ref = self.document(document_id)
-        write_result = await document_ref.create(document_data)
+        document_ref, kwargs = self._prep_add(
+            document_data, document_id, retry, timeout,
+        )
+        write_result = await document_ref.create(document_data, **kwargs)
         return write_result.update_time, document_ref
 
     async def list_documents(
-        self, page_size: int = None
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
     ) -> AsyncGenerator[DocumentReference, None]:
         """List all subdocuments of the current collection.
 
         Args:
             page_size (Optional[int]]): The maximum number of documents
-            in each page of results from this request. Non-positive values
-            are ignored. Defaults to a sensible value set by the API.
+                in each page of results from this request. Non-positive values
+                are ignored. Defaults to a sensible value set by the API.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.DocumentReference`]:
@@ -118,21 +129,20 @@ class AsyncCollectionReference(BaseCollectionReference):
                 collection does not exist at the time of `snapshot`, the
                 iterator will be empty
         """
-        parent, _ = self._parent_info()
+        request, kwargs = self._prep_list_documents(page_size, retry, timeout)
 
         iterator = await self._client._firestore_api.list_documents(
-            request={
-                "parent": parent,
-                "collection_id": self.id,
-                "page_size": page_size,
-                "show_missing": True,
-            },
-            metadata=self._client._rpc_metadata,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
         async for i in iterator:
             yield _item_to_document_ref(self, i)
 
-    async def get(self, transaction: Transaction = None) -> list:
+    async def get(
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> list:
         """Read the documents in this collection.
 
         This sends a ``RunQuery`` RPC and returns a list of documents
@@ -142,6 +152,9 @@ class AsyncCollectionReference(BaseCollectionReference):
             transaction
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -150,11 +163,15 @@ class AsyncCollectionReference(BaseCollectionReference):
         Returns:
             list: The documents in this collection that match the query.
         """
-        query = self._query()
-        return await query.get(transaction=transaction)
+        query, kwargs = self._prep_get_or_stream(retry, timeout)
+
+        return await query.get(transaction=transaction, **kwargs)
 
     async def stream(
-        self, transaction: Transaction = None
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> AsyncIterator[async_document.DocumentSnapshot]:
         """Read the documents in this collection.
 
@@ -177,11 +194,15 @@ class AsyncCollectionReference(BaseCollectionReference):
             transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.\
                 Transaction`]):
                 An existing transaction that the query will run in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Yields:
             :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:
             The next document that fulfills the query.
         """
-        query = async_query.AsyncQuery(self)
-        async for d in query.stream(transaction=transaction):
+        query, kwargs = self._prep_get_or_stream(retry, timeout)
+
+        async for d in query.stream(transaction=transaction, **kwargs):
             yield d  # pytype: disable=name-error

--- a/google/cloud/firestore_v1/async_collection.py
+++ b/google/cloud/firestore_v1/async_collection.py
@@ -89,8 +89,9 @@ class AsyncCollectionReference(BaseCollectionReference):
                 a random 20 character string composed of digits,
                 uppercase and lowercase letters).
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Tuple[:class:`google.protobuf.timestamp_pb2.Timestamp`, \
@@ -120,8 +121,9 @@ class AsyncCollectionReference(BaseCollectionReference):
                 in each page of results from this request. Non-positive values
                 are ignored. Defaults to a sensible value set by the API.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.DocumentReference`]:
@@ -153,8 +155,9 @@ class AsyncCollectionReference(BaseCollectionReference):
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -195,8 +198,9 @@ class AsyncCollectionReference(BaseCollectionReference):
                 Transaction`]):
                 An existing transaction that the query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:

--- a/google/cloud/firestore_v1/async_document.py
+++ b/google/cloud/firestore_v1/async_document.py
@@ -398,7 +398,7 @@ class AsyncDocumentReference(BaseDocumentReference):
             for i in iterator.collection_ids:
                 yield self.collection(i)
             if iterator.next_page_token:
-                next_request = request.cpoy()
+                next_request = request.copy()
                 next_request["page_token"] = iterator.next_page_token
                 iterator = await self._client._firestore_api.list_collection_ids(
                     request=request, metadata=self._client._rpc_metadata, **kwargs

--- a/google/cloud/firestore_v1/async_document.py
+++ b/google/cloud/firestore_v1/async_document.py
@@ -14,6 +14,8 @@
 
 """Classes for representing documents for the Google Cloud Firestore API."""
 
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1.base_document import (
     BaseDocumentReference,
     DocumentSnapshot,
@@ -22,7 +24,6 @@ from google.cloud.firestore_v1.base_document import (
 
 from google.api_core import exceptions  # type: ignore
 from google.cloud.firestore_v1 import _helpers
-from google.cloud.firestore_v1.types import common
 from typing import Any, AsyncGenerator, Coroutine, Iterable, Union
 
 
@@ -54,12 +55,17 @@ class AsyncDocumentReference(BaseDocumentReference):
     def __init__(self, *path, **kwargs) -> None:
         super(AsyncDocumentReference, self).__init__(*path, **kwargs)
 
-    async def create(self, document_data: dict) -> Coroutine:
+    async def create(
+        self, document_data: dict, retry: retries.Retry = None, timeout: float = None,
+    ) -> Coroutine:
         """Create the current document in the Firestore database.
 
         Args:
             document_data (dict): Property names and values to use for
                 creating a document.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -70,12 +76,17 @@ class AsyncDocumentReference(BaseDocumentReference):
             :class:`~google.cloud.exceptions.Conflict`:
                 If the document already exists.
         """
-        batch = self._client.batch()
-        batch.create(self, document_data)
-        write_results = await batch.commit()
+        batch, kwargs = self._prep_create(document_data, retry, timeout)
+        write_results = await batch.commit(**kwargs)
         return _first_write_result(write_results)
 
-    async def set(self, document_data: dict, merge: bool = False) -> Coroutine:
+    async def set(
+        self,
+        document_data: dict,
+        merge: bool = False,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Coroutine:
         """Replace the current document in the Firestore database.
 
         A write ``option`` can be specified to indicate preconditions of
@@ -95,19 +106,25 @@ class AsyncDocumentReference(BaseDocumentReference):
             merge (Optional[bool] or Optional[List<apispec>]):
                 If True, apply merging instead of overwriting the state
                 of the document.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
             The write result corresponding to the committed document. A write
             result contains an ``update_time`` field.
         """
-        batch = self._client.batch()
-        batch.set(self, document_data, merge=merge)
-        write_results = await batch.commit()
+        batch, kwargs = self._prep_set(document_data, merge, retry, timeout)
+        write_results = await batch.commit(**kwargs)
         return _first_write_result(write_results)
 
     async def update(
-        self, field_updates: dict, option: _helpers.WriteOption = None
+        self,
+        field_updates: dict,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Coroutine:
         """Update an existing document in the Firestore database.
 
@@ -242,6 +259,9 @@ class AsyncDocumentReference(BaseDocumentReference):
             option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -251,18 +271,25 @@ class AsyncDocumentReference(BaseDocumentReference):
         Raises:
             ~google.cloud.exceptions.NotFound: If the document does not exist.
         """
-        batch = self._client.batch()
-        batch.update(self, field_updates, option=option)
-        write_results = await batch.commit()
+        batch, kwargs = self._prep_update(field_updates, option, retry, timeout)
+        write_results = await batch.commit(**kwargs)
         return _first_write_result(write_results)
 
-    async def delete(self, option: _helpers.WriteOption = None) -> Coroutine:
+    async def delete(
+        self,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Coroutine:
         """Delete the current document in the Firestore database.
 
         Args:
             option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`google.protobuf.timestamp_pb2.Timestamp`:
@@ -271,20 +298,20 @@ class AsyncDocumentReference(BaseDocumentReference):
             nothing was deleted), this method will still succeed and will
             still return the time that the request was received by the server.
         """
-        write_pb = _helpers.pb_for_delete(self._document_path, option)
+        request, kwargs = self._prep_delete(option, retry, timeout)
+
         commit_response = await self._client._firestore_api.commit(
-            request={
-                "database": self._client._database_string,
-                "writes": [write_pb],
-                "transaction": None,
-            },
-            metadata=self._client._rpc_metadata,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
 
         return commit_response.commit_time
 
     async def get(
-        self, field_paths: Iterable[str] = None, transaction=None
+        self,
+        field_paths: Iterable[str] = None,
+        transaction=None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Union[DocumentSnapshot, Coroutine[Any, Any, DocumentSnapshot]]:
         """Retrieve a snapshot of the current document.
 
@@ -303,6 +330,9 @@ class AsyncDocumentReference(BaseDocumentReference):
             transaction (Optional[:class:`~google.cloud.firestore_v1.async_transaction.AsyncTransaction`]):
                 An existing transaction that this reference
                 will be retrieved in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.base_document.DocumentSnapshot`:
@@ -312,23 +342,12 @@ class AsyncDocumentReference(BaseDocumentReference):
                 :attr:`create_time` attributes will all be ``None`` and
                 its :attr:`exists` attribute will be ``False``.
         """
-        if isinstance(field_paths, str):
-            raise ValueError("'field_paths' must be a sequence of paths, not a string.")
-
-        if field_paths is not None:
-            mask = common.DocumentMask(field_paths=sorted(field_paths))
-        else:
-            mask = None
+        request, kwargs = self._prep_get(field_paths, transaction, retry, timeout)
 
         firestore_api = self._client._firestore_api
         try:
             document_pb = await firestore_api.get_document(
-                request={
-                    "name": self._document_path,
-                    "mask": mask,
-                    "transaction": _helpers.get_transaction_id(transaction),
-                },
-                metadata=self._client._rpc_metadata,
+                request=request, metadata=self._client._rpc_metadata, **kwargs,
             )
         except exceptions.NotFound:
             data = None
@@ -350,13 +369,18 @@ class AsyncDocumentReference(BaseDocumentReference):
             update_time=update_time,
         )
 
-    async def collections(self, page_size: int = None) -> AsyncGenerator:
+    async def collections(
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+    ) -> AsyncGenerator:
         """List subcollections of the current document.
 
         Args:
             page_size (Optional[int]]): The maximum number of collections
-            in each page of results from this request. Non-positive values
-            are ignored. Defaults to a sensible value set by the API.
+                in each page of results from this request. Non-positive values
+                are ignored. Defaults to a sensible value set by the API.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.async_collection.AsyncCollectionReference`]:
@@ -364,22 +388,20 @@ class AsyncDocumentReference(BaseDocumentReference):
                 document does not exist at the time of `snapshot`, the
                 iterator will be empty
         """
+        request, kwargs = self._prep_collections(page_size, retry, timeout)
+
         iterator = await self._client._firestore_api.list_collection_ids(
-            request={"parent": self._document_path, "page_size": page_size},
-            metadata=self._client._rpc_metadata,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
 
         while True:
             for i in iterator.collection_ids:
                 yield self.collection(i)
             if iterator.next_page_token:
+                next_request = request.cpoy()
+                next_request["page_token"] = iterator.next_page_token
                 iterator = await self._client._firestore_api.list_collection_ids(
-                    request={
-                        "parent": self._document_path,
-                        "page_size": page_size,
-                        "page_token": iterator.next_page_token,
-                    },
-                    metadata=self._client._rpc_metadata,
+                    request=request, metadata=self._client._rpc_metadata, **kwargs
                 )
             else:
                 return

--- a/google/cloud/firestore_v1/async_document.py
+++ b/google/cloud/firestore_v1/async_document.py
@@ -64,8 +64,9 @@ class AsyncDocumentReference(BaseDocumentReference):
             document_data (dict): Property names and values to use for
                 creating a document.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -107,8 +108,9 @@ class AsyncDocumentReference(BaseDocumentReference):
                 If True, apply merging instead of overwriting the state
                 of the document.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -260,8 +262,9 @@ class AsyncDocumentReference(BaseDocumentReference):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -288,8 +291,9 @@ class AsyncDocumentReference(BaseDocumentReference):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`google.protobuf.timestamp_pb2.Timestamp`:
@@ -331,8 +335,9 @@ class AsyncDocumentReference(BaseDocumentReference):
                 An existing transaction that this reference
                 will be retrieved in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.base_document.DocumentSnapshot`:
@@ -379,8 +384,9 @@ class AsyncDocumentReference(BaseDocumentReference):
                 in each page of results from this request. Non-positive values
                 are ignored. Defaults to a sensible value set by the API.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.async_collection.AsyncCollectionReference`]:

--- a/google/cloud/firestore_v1/async_document.py
+++ b/google/cloud/firestore_v1/async_document.py
@@ -14,6 +14,7 @@
 
 """Classes for representing documents for the Google Cloud Firestore API."""
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_document import (
@@ -56,7 +57,10 @@ class AsyncDocumentReference(BaseDocumentReference):
         super(AsyncDocumentReference, self).__init__(*path, **kwargs)
 
     async def create(
-        self, document_data: dict, retry: retries.Retry = None, timeout: float = None,
+        self,
+        document_data: dict,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Coroutine:
         """Create the current document in the Firestore database.
 
@@ -85,7 +89,7 @@ class AsyncDocumentReference(BaseDocumentReference):
         self,
         document_data: dict,
         merge: bool = False,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Coroutine:
         """Replace the current document in the Firestore database.
@@ -125,7 +129,7 @@ class AsyncDocumentReference(BaseDocumentReference):
         self,
         field_updates: dict,
         option: _helpers.WriteOption = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Coroutine:
         """Update an existing document in the Firestore database.
@@ -281,7 +285,7 @@ class AsyncDocumentReference(BaseDocumentReference):
     async def delete(
         self,
         option: _helpers.WriteOption = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Coroutine:
         """Delete the current document in the Firestore database.
@@ -314,7 +318,7 @@ class AsyncDocumentReference(BaseDocumentReference):
         self,
         field_paths: Iterable[str] = None,
         transaction=None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Union[DocumentSnapshot, Coroutine[Any, Any, DocumentSnapshot]]:
         """Retrieve a snapshot of the current document.
@@ -375,7 +379,10 @@ class AsyncDocumentReference(BaseDocumentReference):
         )
 
     async def collections(
-        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        page_size: int = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> AsyncGenerator:
         """List subcollections of the current document.
 

--- a/google/cloud/firestore_v1/async_query.py
+++ b/google/cloud/firestore_v1/async_query.py
@@ -18,6 +18,9 @@ A :class:`~google.cloud.firestore_v1.query.Query` can be created directly from
 a :class:`~google.cloud.firestore_v1.collection.Collection` and that can be
 a more common way to create a query than direct usage of the constructor.
 """
+
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1.base_query import (
     BaseCollectionGroup,
     BaseQuery,
@@ -27,7 +30,6 @@ from google.cloud.firestore_v1.base_query import (
     _enum_from_direction,
 )
 
-from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1 import async_document
 from typing import AsyncGenerator
 
@@ -117,7 +119,12 @@ class AsyncQuery(BaseQuery):
             all_descendants=all_descendants,
         )
 
-    async def get(self, transaction: Transaction = None) -> list:
+    async def get(
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> list:
         """Read the documents in the collection that match this query.
 
         This sends a ``RunQuery`` RPC and returns a list of documents
@@ -127,6 +134,9 @@ class AsyncQuery(BaseQuery):
             transaction
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -149,7 +159,7 @@ class AsyncQuery(BaseQuery):
                 )
             self._limit_to_last = False
 
-        result = self.stream(transaction=transaction)
+        result = self.stream(transaction=transaction, retry=retry, timeout=timeout)
         result = [d async for d in result]
         if is_limited_to_last:
             result = list(reversed(result))
@@ -157,7 +167,7 @@ class AsyncQuery(BaseQuery):
         return result
 
     async def stream(
-        self, transaction: Transaction = None
+        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
     ) -> AsyncGenerator[async_document.DocumentSnapshot, None]:
         """Read the documents in the collection that match this query.
 
@@ -180,25 +190,20 @@ class AsyncQuery(BaseQuery):
             transaction
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Yields:
             :class:`~google.cloud.firestore_v1.async_document.DocumentSnapshot`:
             The next document that fulfills the query.
         """
-        if self._limit_to_last:
-            raise ValueError(
-                "Query results for queries that include limit_to_last() "
-                "constraints cannot be streamed. Use Query.get() instead."
-            )
+        request, expected_prefix, kwargs = self._prep_stream(
+            transaction, retry, timeout,
+        )
 
-        parent_path, expected_prefix = self._parent._parent_info()
         response_iterator = await self._client._firestore_api.run_query(
-            request={
-                "parent": parent_path,
-                "structured_query": self._to_protobuf(),
-                "transaction": _helpers.get_transaction_id(transaction),
-            },
-            metadata=self._client._rpc_metadata,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
 
         async for response in response_iterator:
@@ -252,8 +257,12 @@ class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
             all_descendants=all_descendants,
         )
 
+    @staticmethod
+    def _get_query_class():
+        return AsyncQuery
+
     async def get_partitions(
-        self, partition_count
+        self, partition_count, retry: retries.Retry = None, timeout: float = None
     ) -> AsyncGenerator[QueryPartition, None]:
         """Partition a query for parallelization.
 
@@ -265,24 +274,13 @@ class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
             partition_count (int): The desired maximum number of partition points. The
                 number must be strictly positive. The actual number of partitions
                 returned may be fewer.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
         """
-        self._validate_partition_query()
-        query = AsyncQuery(
-            self._parent,
-            orders=self._PARTITION_QUERY_ORDER,
-            start_at=self._start_at,
-            end_at=self._end_at,
-            all_descendants=self._all_descendants,
-        )
-
-        parent_path, expected_prefix = self._parent._parent_info()
+        request, kwargs = self._prep_get_partitions(partition_count, retry, timeout)
         pager = await self._client._firestore_api.partition_query(
-            request={
-                "parent": parent_path,
-                "structured_query": query._to_protobuf(),
-                "partition_count": partition_count,
-            },
-            metadata=self._client._rpc_metadata,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
 
         start_at = None

--- a/google/cloud/firestore_v1/async_query.py
+++ b/google/cloud/firestore_v1/async_query.py
@@ -135,8 +135,9 @@ class AsyncQuery(BaseQuery):
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -191,8 +192,9 @@ class AsyncQuery(BaseQuery):
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             :class:`~google.cloud.firestore_v1.async_document.DocumentSnapshot`:
@@ -275,8 +277,9 @@ class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
                 number must be strictly positive. The actual number of partitions
                 returned may be fewer.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
         """
         request, kwargs = self._prep_get_partitions(partition_count, retry, timeout)
         pager = await self._client._firestore_api.partition_query(

--- a/google/cloud/firestore_v1/async_query.py
+++ b/google/cloud/firestore_v1/async_query.py
@@ -19,6 +19,7 @@ a :class:`~google.cloud.firestore_v1.collection.Collection` and that can be
 a more common way to create a query than direct usage of the constructor.
 """
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_query import (
@@ -122,7 +123,7 @@ class AsyncQuery(BaseQuery):
     async def get(
         self,
         transaction: Transaction = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> list:
         """Read the documents in the collection that match this query.
@@ -168,7 +169,10 @@ class AsyncQuery(BaseQuery):
         return result
 
     async def stream(
-        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        transaction=None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> AsyncGenerator[async_document.DocumentSnapshot, None]:
         """Read the documents in the collection that match this query.
 
@@ -264,7 +268,10 @@ class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
         return AsyncQuery
 
     async def get_partitions(
-        self, partition_count, retry: retries.Retry = None, timeout: float = None
+        self,
+        partition_count,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> AsyncGenerator[QueryPartition, None]:
         """Partition a query for parallelization.
 

--- a/google/cloud/firestore_v1/async_transaction.py
+++ b/google/cloud/firestore_v1/async_transaction.py
@@ -18,6 +18,8 @@
 import asyncio
 import random
 
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1.base_transaction import (
     _BaseTransactional,
     BaseTransaction,
@@ -34,6 +36,7 @@ from google.cloud.firestore_v1.base_transaction import (
 
 from google.api_core import exceptions  # type: ignore
 from google.cloud.firestore_v1 import async_batch
+from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1 import types
 
 from google.cloud.firestore_v1.async_document import AsyncDocumentReference
@@ -144,32 +147,48 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         self._clean_up()
         return list(commit_response.write_results)
 
-    async def get_all(self, references: list) -> Coroutine:
+    async def get_all(
+        self, references: list, retry: retries.Retry = None, timeout: float = None
+    ) -> Coroutine:
         """Retrieves multiple documents from Firestore.
 
         Args:
             references (List[.AsyncDocumentReference, ...]): Iterable of document
                 references to be retrieved.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.
         """
-        return await self._client.get_all(references, transaction=self)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+        return await self._client.get_all(references, transaction=self, **kwargs)
 
-    async def get(self, ref_or_query) -> AsyncGenerator[DocumentSnapshot, Any]:
+    async def get(
+        self, ref_or_query, retry: retries.Retry = None, timeout: float = None
+    ) -> AsyncGenerator[DocumentSnapshot, Any]:
         """
         Retrieve a document or a query result from the database.
+
         Args:
             ref_or_query The document references or query object to return.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.
         """
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         if isinstance(ref_or_query, AsyncDocumentReference):
-            return await self._client.get_all([ref_or_query], transaction=self)
+            return await self._client.get_all(
+                [ref_or_query], transaction=self, **kwargs
+            )
         elif isinstance(ref_or_query, AsyncQuery):
-            return await ref_or_query.stream(transaction=self)
+            return await ref_or_query.stream(transaction=self, **kwargs)
         else:
             raise ValueError(
                 'Value for argument "ref_or_query" must be a AsyncDocumentReference or a AsyncQuery.'

--- a/google/cloud/firestore_v1/async_transaction.py
+++ b/google/cloud/firestore_v1/async_transaction.py
@@ -156,8 +156,9 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
             references (List[.AsyncDocumentReference, ...]): Iterable of document
                 references to be retrieved.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
@@ -175,8 +176,9 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         Args:
             ref_or_query The document references or query object to return.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the

--- a/google/cloud/firestore_v1/async_transaction.py
+++ b/google/cloud/firestore_v1/async_transaction.py
@@ -18,6 +18,7 @@
 import asyncio
 import random
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_transaction import (
@@ -148,7 +149,10 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         return list(commit_response.write_results)
 
     async def get_all(
-        self, references: list, retry: retries.Retry = None, timeout: float = None
+        self,
+        references: list,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Coroutine:
         """Retrieves multiple documents from Firestore.
 
@@ -168,7 +172,10 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         return await self._client.get_all(references, transaction=self, **kwargs)
 
     async def get(
-        self, ref_or_query, retry: retries.Retry = None, timeout: float = None
+        self,
+        ref_or_query,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> AsyncGenerator[DocumentSnapshot, Any]:
         """
         Retrieve a document or a query result from the database.

--- a/google/cloud/firestore_v1/base_batch.py
+++ b/google/cloud/firestore_v1/base_batch.py
@@ -19,6 +19,7 @@ from google.cloud.firestore_v1 import _helpers
 
 # Types needed only for Type Hints
 from google.cloud.firestore_v1.document import DocumentReference
+
 from typing import Union
 
 
@@ -146,3 +147,13 @@ class BaseWriteBatch(object):
         """
         write_pb = _helpers.pb_for_delete(reference._document_path, option)
         self._add_write_pbs([write_pb])
+
+    def _prep_commit(self, retry, timeout):
+        """Shared setup for async/sync :meth:`commit`."""
+        request = {
+            "database": self._client._database_string,
+            "writes": self._write_pbs,
+            "transaction": None,
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+        return request, kwargs

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -28,6 +28,7 @@ import os
 
 import google.api_core.client_options  # type: ignore
 import google.api_core.path_template  # type: ignore
+from google.api_core import retry as retries  # type: ignore
 from google.api_core.gapic_v1 import client_info  # type: ignore
 from google.cloud.client import ClientWithProject  # type: ignore
 
@@ -358,13 +359,15 @@ class BaseClient(ClientWithProject):
         references: list,
         field_paths: Iterable[str] = None,
         transaction: BaseTransaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Union[
         AsyncGenerator[DocumentSnapshot, Any], Generator[DocumentSnapshot, Any, Any]
     ]:
         raise NotImplementedError
 
     def collections(
-        self,
+        self, retry: retries.Retry = None, timeout: float = None,
     ) -> Union[
         AsyncGenerator[BaseCollectionReference, Any],
         Generator[BaseCollectionReference, Any, Any],

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -15,6 +15,8 @@
 """Classes for representing collections for the Google Cloud Firestore API."""
 import random
 
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1.document import DocumentReference
 from typing import (
@@ -147,12 +149,16 @@ class BaseCollectionReference(object):
         return parent_path, expected_prefix
 
     def add(
-        self, document_data: dict, document_id: str = None
+        self,
+        document_data: dict,
+        document_id: str = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Union[Tuple[Any, Any], Coroutine[Any, Any, Tuple[Any, Any]]]:
         raise NotImplementedError
 
     def list_documents(
-        self, page_size: int = None
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
     ) -> Union[
         Generator[DocumentReference, Any, Any], AsyncGenerator[DocumentReference, Any]
     ]:
@@ -374,14 +380,20 @@ class BaseCollectionReference(object):
         return query.end_at(document_fields)
 
     def get(
-        self, transaction: Transaction = None
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Union[
         Generator[DocumentSnapshot, Any, Any], AsyncGenerator[DocumentSnapshot, Any]
     ]:
         raise NotImplementedError
 
     def stream(
-        self, transaction: Transaction = None
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Union[Iterator[DocumentSnapshot], AsyncIterator[DocumentSnapshot]]:
         raise NotImplementedError
 

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -148,6 +148,22 @@ class BaseCollectionReference(object):
         expected_prefix = _helpers.DOCUMENT_PATH_DELIMITER.join((parent_path, self.id))
         return parent_path, expected_prefix
 
+    def _prep_add(
+        self,
+        document_data: dict,
+        document_id: str = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Tuple[DocumentReference, dict]:
+        """Shared setup for async / sync :method:`add`"""
+        if document_id is None:
+            document_id = _auto_id()
+
+        document_ref = self.document(document_id)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return document_ref, kwargs
+
     def add(
         self,
         document_data: dict,
@@ -156,6 +172,21 @@ class BaseCollectionReference(object):
         timeout: float = None,
     ) -> Union[Tuple[Any, Any], Coroutine[Any, Any, Tuple[Any, Any]]]:
         raise NotImplementedError
+
+    def _prep_list_documents(
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+    ) -> Tuple[dict, dict]:
+        """Shared setup for async / sync :method:`list_documents`"""
+        parent, _ = self._parent_info()
+        request = {
+            "parent": parent,
+            "collection_id": self.id,
+            "page_size": page_size,
+            "show_missing": True,
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return request, kwargs
 
     def list_documents(
         self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
@@ -378,6 +409,15 @@ class BaseCollectionReference(object):
         """
         query = self._query()
         return query.end_at(document_fields)
+
+    def _prep_get_or_stream(
+        self, retry: retries.Retry = None, timeout: float = None,
+    ) -> Tuple[Any, dict]:
+        """Shared setup for async / sync :meth:`get` / :meth:`stream`"""
+        query = self._query()
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return query, kwargs
 
     def get(
         self,

--- a/google/cloud/firestore_v1/base_document.py
+++ b/google/cloud/firestore_v1/base_document.py
@@ -16,6 +16,8 @@
 
 import copy
 
+from google.api_core import retry as retries  # type: ignore
+
 from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1 import field_path as field_path_module
 from typing import Any, Iterable, NoReturn, Tuple
@@ -178,26 +180,49 @@ class BaseDocumentReference(object):
         child_path = self._path + (collection_id,)
         return self._client.collection(*child_path)
 
-    def create(self, document_data: dict) -> NoReturn:
-        raise NotImplementedError
-
-    def set(self, document_data: dict, merge: bool = False) -> NoReturn:
-        raise NotImplementedError
-
-    def update(
-        self, field_updates: dict, option: _helpers.WriteOption = None
+    def create(
+        self, document_data: dict, retry: retries.Retry = None, timeout: float = None,
     ) -> NoReturn:
         raise NotImplementedError
 
-    def delete(self, option: _helpers.WriteOption = None) -> NoReturn:
+    def set(
+        self,
+        document_data: dict,
+        merge: bool = False,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> NoReturn:
+        raise NotImplementedError
+
+    def update(
+        self,
+        field_updates: dict,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> NoReturn:
+        raise NotImplementedError
+
+    def delete(
+        self,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> NoReturn:
         raise NotImplementedError
 
     def get(
-        self, field_paths: Iterable[str] = None, transaction=None
+        self,
+        field_paths: Iterable[str] = None,
+        transaction=None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> "DocumentSnapshot":
         raise NotImplementedError
 
-    def collections(self, page_size: int = None) -> NoReturn:
+    def collections(
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+    ) -> NoReturn:
         raise NotImplementedError
 
     def on_snapshot(self, callback) -> NoReturn:

--- a/google/cloud/firestore_v1/base_document.py
+++ b/google/cloud/firestore_v1/base_document.py
@@ -20,7 +20,12 @@ from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1 import field_path as field_path_module
-from typing import Any, Iterable, NoReturn, Tuple
+from google.cloud.firestore_v1.types import common
+
+from typing import Any
+from typing import Iterable
+from typing import NoReturn
+from typing import Tuple
 
 
 class BaseDocumentReference(object):
@@ -180,10 +185,32 @@ class BaseDocumentReference(object):
         child_path = self._path + (collection_id,)
         return self._client.collection(*child_path)
 
+    def _prep_create(
+        self, document_data: dict, retry: retries.Retry = None, timeout: float = None,
+    ) -> Tuple[Any, dict]:
+        batch = self._client.batch()
+        batch.create(self, document_data)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return batch, kwargs
+
     def create(
         self, document_data: dict, retry: retries.Retry = None, timeout: float = None,
     ) -> NoReturn:
         raise NotImplementedError
+
+    def _prep_set(
+        self,
+        document_data: dict,
+        merge: bool = False,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Tuple[Any, dict]:
+        batch = self._client.batch()
+        batch.set(self, document_data, merge=merge)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return batch, kwargs
 
     def set(
         self,
@@ -194,6 +221,19 @@ class BaseDocumentReference(object):
     ) -> NoReturn:
         raise NotImplementedError
 
+    def _prep_update(
+        self,
+        field_updates: dict,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Tuple[Any, dict]:
+        batch = self._client.batch()
+        batch.update(self, field_updates, option=option)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return batch, kwargs
+
     def update(
         self,
         field_updates: dict,
@@ -203,6 +243,23 @@ class BaseDocumentReference(object):
     ) -> NoReturn:
         raise NotImplementedError
 
+    def _prep_delete(
+        self,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Tuple[dict, dict]:
+        """Shared setup for async/sync :meth:`delete`."""
+        write_pb = _helpers.pb_for_delete(self._document_path, option)
+        request = {
+            "database": self._client._database_string,
+            "writes": [write_pb],
+            "transaction": None,
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return request, kwargs
+
     def delete(
         self,
         option: _helpers.WriteOption = None,
@@ -210,6 +267,31 @@ class BaseDocumentReference(object):
         timeout: float = None,
     ) -> NoReturn:
         raise NotImplementedError
+
+    def _prep_get(
+        self,
+        field_paths: Iterable[str] = None,
+        transaction=None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Tuple[dict, dict]:
+        """Shared setup for async/sync :meth:`get`."""
+        if isinstance(field_paths, str):
+            raise ValueError("'field_paths' must be a sequence of paths, not a string.")
+
+        if field_paths is not None:
+            mask = common.DocumentMask(field_paths=sorted(field_paths))
+        else:
+            mask = None
+
+        request = {
+            "name": self._document_path,
+            "mask": mask,
+            "transaction": _helpers.get_transaction_id(transaction),
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return request, kwargs
 
     def get(
         self,
@@ -219,6 +301,15 @@ class BaseDocumentReference(object):
         timeout: float = None,
     ) -> "DocumentSnapshot":
         raise NotImplementedError
+
+    def _prep_collections(
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+    ) -> Tuple[dict, dict]:
+        """Shared setup for async/sync :meth:`collections`."""
+        request = {"parent": self._document_path, "page_size": page_size}
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return request, kwargs
 
     def collections(
         self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -21,6 +21,7 @@ a more common way to create a query than direct usage of the constructor.
 import copy
 import math
 
+from google.api_core import retry as retries  # type: ignore
 from google.protobuf import wrappers_pb2
 
 from google.cloud.firestore_v1 import _helpers
@@ -800,10 +801,14 @@ class BaseQuery(object):
 
         return query.StructuredQuery(**query_kwargs)
 
-    def get(self, transaction=None) -> NoReturn:
+    def get(
+        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+    ) -> NoReturn:
         raise NotImplementedError
 
-    def stream(self, transaction=None) -> NoReturn:
+    def stream(
+        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+    ) -> NoReturn:
         raise NotImplementedError
 
     def on_snapshot(self, callback) -> NoReturn:
@@ -1098,6 +1103,11 @@ class BaseCollectionGroup(BaseQuery):
 
         if self._offset:
             raise ValueError("Can't partition query with offset.")
+
+    def get_partitions(
+        self, partition_count, retry: retries.Retry = None, timeout: float = None,
+    ) -> NoReturn:
+        raise NotImplementedError
 
 
 class QueryPartition:

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -806,6 +806,26 @@ class BaseQuery(object):
     ) -> NoReturn:
         raise NotImplementedError
 
+    def _prep_stream(
+        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+    ) -> Tuple[dict, str, dict]:
+        """Shared setup for async / sync :meth:`stream`"""
+        if self._limit_to_last:
+            raise ValueError(
+                "Query results for queries that include limit_to_last() "
+                "constraints cannot be streamed. Use Query.get() instead."
+            )
+
+        parent_path, expected_prefix = self._parent._parent_info()
+        request = {
+            "parent": parent_path,
+            "structured_query": self._to_protobuf(),
+            "transaction": _helpers.get_transaction_id(transaction),
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return request, expected_prefix, kwargs
+
     def stream(
         self, transaction=None, retry: retries.Retry = None, timeout: float = None,
     ) -> NoReturn:
@@ -1103,6 +1123,28 @@ class BaseCollectionGroup(BaseQuery):
 
         if self._offset:
             raise ValueError("Can't partition query with offset.")
+
+    def _prep_get_partitions(
+        self, partition_count, retry: retries.Retry = None, timeout: float = None,
+    ) -> Tuple[dict, dict]:
+        self._validate_partition_query()
+        parent_path, expected_prefix = self._parent._parent_info()
+        klass = self._get_query_class()
+        query = klass(
+            self._parent,
+            orders=self._PARTITION_QUERY_ORDER,
+            start_at=self._start_at,
+            end_at=self._end_at,
+            all_descendants=self._all_descendants,
+        )
+        request = {
+            "parent": parent_path,
+            "structured_query": query._to_protobuf(),
+            "partition_count": partition_count,
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        return request, kwargs
 
     def get_partitions(
         self, partition_count, retry: retries.Retry = None, timeout: float = None,

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -1124,6 +1124,9 @@ class BaseCollectionGroup(BaseQuery):
         if self._offset:
             raise ValueError("Can't partition query with offset.")
 
+    def _get_query_class(self):
+        raise NotImplementedError
+
     def _prep_get_partitions(
         self, partition_count, retry: retries.Retry = None, timeout: float = None,
     ) -> Tuple[dict, dict]:

--- a/google/cloud/firestore_v1/base_transaction.py
+++ b/google/cloud/firestore_v1/base_transaction.py
@@ -14,6 +14,7 @@
 
 """Helpers for applying Google Cloud Firestore changes in a transaction."""
 
+from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1 import types
 from typing import Any, Coroutine, NoReturn, Optional, Union
@@ -141,10 +142,14 @@ class BaseTransaction(object):
     def _commit(self) -> Union[list, Coroutine[Any, Any, list]]:
         raise NotImplementedError
 
-    def get_all(self, references: list) -> NoReturn:
+    def get_all(
+        self, references: list, retry: retries.Retry = None, timeout: float = None,
+    ) -> NoReturn:
         raise NotImplementedError
 
-    def get(self, ref_or_query) -> NoReturn:
+    def get(
+        self, ref_or_query, retry: retries.Retry = None, timeout: float = None,
+    ) -> NoReturn:
         raise NotImplementedError
 
 

--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -14,6 +14,7 @@
 
 """Helpers for batch requests to the Google Cloud Firestore API."""
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_batch import BaseWriteBatch
@@ -34,7 +35,9 @@ class WriteBatch(BaseWriteBatch):
     def __init__(self, client) -> None:
         super(WriteBatch, self).__init__(client=client)
 
-    def commit(self, retry: retries.Retry = None, timeout: float = None) -> list:
+    def commit(
+        self, retry: retries.Retry = gapic_v1.method.DEFAULT, timeout: float = None
+    ) -> list:
         """Commit the changes accumulated in this batch.
 
         Args:

--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -37,7 +37,7 @@ class WriteBatch(BaseWriteBatch):
     def commit(self, retry: retries.Retry = None, timeout: float = None) -> list:
         """Commit the changes accumulated in this batch.
 
-        Args
+        Args:
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.

--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -17,6 +17,7 @@
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_batch import BaseWriteBatch
+from google.cloud.firestore_v1 import _helpers
 
 
 class WriteBatch(BaseWriteBatch):
@@ -48,13 +49,7 @@ class WriteBatch(BaseWriteBatch):
             in the same order as the changes were applied to this batch. A
             write result contains an ``update_time`` field.
         """
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         commit_response = self._client._firestore_api.commit(
             request={

--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -39,8 +39,9 @@ class WriteBatch(BaseWriteBatch):
 
         Args:
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:

--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -17,7 +17,6 @@
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_batch import BaseWriteBatch
-from google.cloud.firestore_v1 import _helpers
 
 
 class WriteBatch(BaseWriteBatch):
@@ -49,21 +48,16 @@ class WriteBatch(BaseWriteBatch):
             in the same order as the changes were applied to this batch. A
             write result contains an ``update_time`` field.
         """
-        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+        request, kwargs = self._prep_commit(retry, timeout)
 
         commit_response = self._client._firestore_api.commit(
-            request={
-                "database": self._client._database_string,
-                "writes": self._write_pbs,
-                "transaction": None,
-            },
-            metadata=self._client._rpc_metadata,
-            **kwargs,
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
         )
 
         self._write_pbs = []
         self.write_results = results = list(commit_response.write_results)
         self.commit_time = commit_response.commit_time
+
         return results
 
     def __enter__(self):

--- a/google/cloud/firestore_v1/client.py
+++ b/google/cloud/firestore_v1/client.py
@@ -279,16 +279,26 @@ class Client(BaseClient):
         for get_doc_response in response_iterator:
             yield _parse_batch_get(get_doc_response, reference_map, self)
 
-    def collections(self) -> Generator[Any, Any, None]:
+    def collections(
+        self, retry: retries.Retry = None, timeout: float = None,
+    ) -> Generator[Any, Any, None]:
         """List top-level collections of the client's database.
+
+        Args:
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.CollectionReference`]:
                 iterator of subcollections of the current document.
         """
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+
         iterator = self._firestore_api.list_collection_ids(
             request={"parent": "{}/documents".format(self._database_string)},
             metadata=self._rpc_metadata,
+            **kwargs,
         )
 
         while True:

--- a/google/cloud/firestore_v1/client.py
+++ b/google/cloud/firestore_v1/client.py
@@ -239,8 +239,9 @@ class Client(BaseClient):
                 An existing transaction that these ``references`` will be
                 retrieved in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
@@ -264,8 +265,9 @@ class Client(BaseClient):
 
         Args:
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.CollectionReference`]:

--- a/google/cloud/firestore_v1/client.py
+++ b/google/cloud/firestore_v1/client.py
@@ -24,6 +24,7 @@ In the hierarchy of API concepts
   :class:`~google.cloud.firestore_v1.document.DocumentReference`
 """
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_client import (
@@ -206,7 +207,7 @@ class Client(BaseClient):
         references: list,
         field_paths: Iterable[str] = None,
         transaction: Transaction = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Generator[Any, Any, None]:
         """Retrieve a batch of documents.
@@ -259,7 +260,7 @@ class Client(BaseClient):
             yield _parse_batch_get(get_doc_response, reference_map, self)
 
     def collections(
-        self, retry: retries.Retry = None, timeout: float = None,
+        self, retry: retries.Retry = gapic_v1.method.DEFAULT, timeout: float = None,
     ) -> Generator[Any, Any, None]:
         """List top-level collections of the client's database.
 

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -14,6 +14,7 @@
 
 """Classes for representing collections for the Google Cloud Firestore API."""
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_collection import (
@@ -70,7 +71,7 @@ class CollectionReference(BaseCollectionReference):
         self,
         document_data: dict,
         document_id: str = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Tuple[Any, Any]:
         """Create a document in the Firestore database with the provided data.
@@ -107,7 +108,10 @@ class CollectionReference(BaseCollectionReference):
         return write_result.update_time, document_ref
 
     def list_documents(
-        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        page_size: int = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Generator[Any, Any, None]:
         """List all subdocuments of the current collection.
 
@@ -136,7 +140,7 @@ class CollectionReference(BaseCollectionReference):
     def get(
         self,
         transaction: Transaction = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> list:
         """Read the documents in this collection.
@@ -167,7 +171,7 @@ class CollectionReference(BaseCollectionReference):
     def stream(
         self,
         transaction: Transaction = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Generator[document.DocumentSnapshot, Any, None]:
         """Read the documents in this collection.

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -154,7 +154,12 @@ class CollectionReference(BaseCollectionReference):
         )
         return (_item_to_document_ref(self, i) for i in iterator)
 
-    def get(self, transaction: Transaction = None) -> list:
+    def get(
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> list:
         """Read the documents in this collection.
 
         This sends a ``RunQuery`` RPC and returns a list of documents
@@ -164,6 +169,9 @@ class CollectionReference(BaseCollectionReference):
             transaction
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -173,7 +181,8 @@ class CollectionReference(BaseCollectionReference):
             list: The documents in this collection that match the query.
         """
         query = query_mod.Query(self)
-        return query.get(transaction=transaction)
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        return query.get(transaction=transaction, **kwargs)
 
     def stream(
         self, transaction: Transaction = None

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -185,7 +185,10 @@ class CollectionReference(BaseCollectionReference):
         return query.get(transaction=transaction, **kwargs)
 
     def stream(
-        self, transaction: Transaction = None
+        self,
+        transaction: Transaction = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
     ) -> Generator[document.DocumentSnapshot, Any, None]:
         """Read the documents in this collection.
 
@@ -208,13 +211,17 @@ class CollectionReference(BaseCollectionReference):
             transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.\
                 Transaction`]):
                 An existing transaction that the query will run in.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Yields:
             :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:
             The next document that fulfills the query.
         """
         query = query_mod.Query(self)
-        return query.stream(transaction=transaction)
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        return query.stream(transaction=transaction, **kwargs)
 
     def on_snapshot(self, callback: Callable) -> Watch:
         """Monitor the documents in this collection.

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -120,13 +120,18 @@ class CollectionReference(BaseCollectionReference):
         write_result = document_ref.create(document_data, **kwargs)
         return write_result.update_time, document_ref
 
-    def list_documents(self, page_size: int = None) -> Generator[Any, Any, None]:
+    def list_documents(
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+    ) -> Generator[Any, Any, None]:
         """List all subdocuments of the current collection.
 
         Args:
             page_size (Optional[int]]): The maximum number of documents
-            in each page of results from this request. Non-positive values
-            are ignored. Defaults to a sensible value set by the API.
+                in each page of results from this request. Non-positive values
+                are ignored. Defaults to a sensible value set by the API.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.DocumentReference`]:
@@ -135,6 +140,7 @@ class CollectionReference(BaseCollectionReference):
                 iterator will be empty
         """
         parent, _ = self._parent_info()
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
 
         iterator = self._client._firestore_api.list_documents(
             request={
@@ -144,6 +150,7 @@ class CollectionReference(BaseCollectionReference):
                 "show_missing": True,
             },
             metadata=self._client._rpc_metadata,
+            **kwargs,
         )
         return (_item_to_document_ref(self, i) for i in iterator)
 

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -84,8 +84,9 @@ class CollectionReference(BaseCollectionReference):
                 a random 20 character string composed of digits,
                 uppercase and lowercase letters).
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Tuple[:class:`google.protobuf.timestamp_pb2.Timestamp`, \
@@ -115,8 +116,9 @@ class CollectionReference(BaseCollectionReference):
                 in each page of results from this request. Non-positive values
                 are ignored. Defaults to a sensible value set by the API.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.DocumentReference`]:
@@ -147,8 +149,9 @@ class CollectionReference(BaseCollectionReference):
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         If a ``transaction`` is used and it already has write operations
         added, this method cannot be used (i.e. read-after-write is not
@@ -189,8 +192,9 @@ class CollectionReference(BaseCollectionReference):
                 Transaction`]):
                 An existing transaction that the query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:

--- a/google/cloud/firestore_v1/collection.py
+++ b/google/cloud/firestore_v1/collection.py
@@ -24,6 +24,7 @@ from google.cloud.firestore_v1.base_collection import (
 from google.cloud.firestore_v1 import query as query_mod
 from google.cloud.firestore_v1.watch import Watch
 from google.cloud.firestore_v1 import document
+from google.cloud.firestore_v1 import _helpers
 from typing import Any, Callable, Generator, Tuple
 
 # Types needed only for Type Hints
@@ -67,18 +68,6 @@ class CollectionReference(BaseCollectionReference):
         """
         return query_mod.Query(self)
 
-    @staticmethod
-    def _make_retry_timeout_kwargs(retry, timeout):
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
-        return kwargs
-
     def add(
         self,
         document_data: dict,
@@ -116,7 +105,7 @@ class CollectionReference(BaseCollectionReference):
             document_id = _auto_id()
 
         document_ref = self.document(document_id)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         write_result = document_ref.create(document_data, **kwargs)
         return write_result.update_time, document_ref
 
@@ -140,7 +129,7 @@ class CollectionReference(BaseCollectionReference):
                 iterator will be empty
         """
         parent, _ = self._parent_info()
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         iterator = self._client._firestore_api.list_documents(
             request={
@@ -181,7 +170,7 @@ class CollectionReference(BaseCollectionReference):
             list: The documents in this collection that match the query.
         """
         query = query_mod.Query(self)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         return query.get(transaction=transaction, **kwargs)
 
     def stream(
@@ -220,7 +209,7 @@ class CollectionReference(BaseCollectionReference):
             The next document that fulfills the query.
         """
         query = query_mod.Query(self)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         return query.stream(transaction=transaction, **kwargs)
 
     def on_snapshot(self, callback: Callable) -> Watch:

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -96,7 +96,13 @@ class DocumentReference(BaseDocumentReference):
         write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
-    def set(self, document_data: dict, merge: bool = False) -> Any:
+    def set(
+        self,
+        document_data: dict,
+        merge: bool = False,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Any:
         """Replace the current document in the Firestore database.
 
         A write ``option`` can be specified to indicate preconditions of
@@ -116,6 +122,9 @@ class DocumentReference(BaseDocumentReference):
             merge (Optional[bool] or Optional[List<apispec>]):
                 If True, apply merging instead of overwriting the state
                 of the document.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -124,7 +133,8 @@ class DocumentReference(BaseDocumentReference):
         """
         batch = self._client.batch()
         batch.set(self, document_data, merge=merge)
-        write_results = batch.commit()
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
     def update(self, field_updates: dict, option: _helpers.WriteOption = None) -> Any:

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -65,8 +65,9 @@ class DocumentReference(BaseDocumentReference):
             document_data (dict): Property names and values to use for
                 creating a document.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -108,8 +109,9 @@ class DocumentReference(BaseDocumentReference):
                 If True, apply merging instead of overwriting the state
                 of the document.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -261,8 +263,9 @@ class DocumentReference(BaseDocumentReference):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -289,8 +292,9 @@ class DocumentReference(BaseDocumentReference):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`google.protobuf.timestamp_pb2.Timestamp`:
@@ -332,8 +336,9 @@ class DocumentReference(BaseDocumentReference):
                 An existing transaction that this reference
                 will be retrieved in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             :class:`~google.cloud.firestore_v1.base_document.DocumentSnapshot`:
@@ -380,8 +385,9 @@ class DocumentReference(BaseDocumentReference):
                 in each page of results from this request. Non-positive values
                 are ignored. Defaults to a sensible value set by the API.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.CollectionReference`]:

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -399,7 +399,7 @@ class DocumentReference(BaseDocumentReference):
             for i in iterator.collection_ids:
                 yield self.collection(i)
             if iterator.next_page_token:
-                next_request = request.cpoy()
+                next_request = request.copy()
                 next_request["page_token"] = iterator.next_page_token
                 iterator = self._client._firestore_api.list_collection_ids(
                     request=request, metadata=self._client._rpc_metadata, **kwargs

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -14,6 +14,7 @@
 
 """Classes for representing documents for the Google Cloud Firestore API."""
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_document import (
@@ -57,7 +58,10 @@ class DocumentReference(BaseDocumentReference):
         super(DocumentReference, self).__init__(*path, **kwargs)
 
     def create(
-        self, document_data: dict, retry: retries.Retry = None, timeout: float = None,
+        self,
+        document_data: dict,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Any:
         """Create the current document in the Firestore database.
 
@@ -86,7 +90,7 @@ class DocumentReference(BaseDocumentReference):
         self,
         document_data: dict,
         merge: bool = False,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Any:
         """Replace the current document in the Firestore database.
@@ -126,7 +130,7 @@ class DocumentReference(BaseDocumentReference):
         self,
         field_updates: dict,
         option: _helpers.WriteOption = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Any:
         """Update an existing document in the Firestore database.
@@ -282,7 +286,7 @@ class DocumentReference(BaseDocumentReference):
     def delete(
         self,
         option: _helpers.WriteOption = None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> Any:
         """Delete the current document in the Firestore database.
@@ -315,7 +319,7 @@ class DocumentReference(BaseDocumentReference):
         self,
         field_paths: Iterable[str] = None,
         transaction=None,
-        retry: retries.Retry = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
         timeout: float = None,
     ) -> DocumentSnapshot:
         """Retrieve a snapshot of the current document.
@@ -376,7 +380,10 @@ class DocumentReference(BaseDocumentReference):
         )
 
     def collections(
-        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        page_size: int = None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Generator[Any, Any, None]:
         """List subcollections of the current document.
 

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -137,7 +137,13 @@ class DocumentReference(BaseDocumentReference):
         write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
-    def update(self, field_updates: dict, option: _helpers.WriteOption = None) -> Any:
+    def update(
+        self,
+        field_updates: dict,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Any:
         """Update an existing document in the Firestore database.
 
         By default, this method verifies that the document exists on the
@@ -271,6 +277,9 @@ class DocumentReference(BaseDocumentReference):
             option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -282,7 +291,8 @@ class DocumentReference(BaseDocumentReference):
         """
         batch = self._client.batch()
         batch.update(self, field_updates, option=option)
-        write_results = batch.commit()
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
     def delete(

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -57,18 +57,6 @@ class DocumentReference(BaseDocumentReference):
     def __init__(self, *path, **kwargs) -> None:
         super(DocumentReference, self).__init__(*path, **kwargs)
 
-    @staticmethod
-    def _make_retry_timeout_kwargs(retry, timeout):
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
-        return kwargs
-
     def create(
         self, document_data, retry: retries.Retry = None, timeout: float = None,
     ) -> Any:
@@ -92,7 +80,7 @@ class DocumentReference(BaseDocumentReference):
         """
         batch = self._client.batch()
         batch.create(self, document_data)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
@@ -133,7 +121,7 @@ class DocumentReference(BaseDocumentReference):
         """
         batch = self._client.batch()
         batch.set(self, document_data, merge=merge)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
@@ -291,7 +279,7 @@ class DocumentReference(BaseDocumentReference):
         """
         batch = self._client.batch()
         batch.update(self, field_updates, option=option)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
@@ -319,7 +307,7 @@ class DocumentReference(BaseDocumentReference):
             still return the time that the request was received by the server.
         """
         write_pb = _helpers.pb_for_delete(self._document_path, option)
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         commit_response = self._client._firestore_api.commit(
             request={
                 "database": self._client._database_string,
@@ -375,7 +363,7 @@ class DocumentReference(BaseDocumentReference):
             mask = common.DocumentMask(field_paths=sorted(field_paths))
         else:
             mask = None
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         firestore_api = self._client._firestore_api
         try:
@@ -427,7 +415,7 @@ class DocumentReference(BaseDocumentReference):
                 document does not exist at the time of `snapshot`, the
                 iterator will be empty
         """
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         iterator = self._client._firestore_api.list_collection_ids(
             request={"parent": self._document_path, "page_size": page_size},

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -372,13 +372,18 @@ class DocumentReference(BaseDocumentReference):
             update_time=update_time,
         )
 
-    def collections(self, page_size: int = None) -> Generator[Any, Any, None]:
+    def collections(
+        self, page_size: int = None, retry: retries.Retry = None, timeout: float = None,
+    ) -> Generator[Any, Any, None]:
         """List subcollections of the current document.
 
         Args:
             page_size (Optional[int]]): The maximum number of collections
-            in each page of results from this request. Non-positive values
-            are ignored. Defaults to a sensible value set by the API.
+                in each page of results from this request. Non-positive values
+                are ignored. Defaults to a sensible value set by the API.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             Sequence[:class:`~google.cloud.firestore_v1.collection.CollectionReference`]:
@@ -386,9 +391,12 @@ class DocumentReference(BaseDocumentReference):
                 document does not exist at the time of `snapshot`, the
                 iterator will be empty
         """
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+
         iterator = self._client._firestore_api.list_collection_ids(
             request={"parent": self._document_path, "page_size": page_size},
             metadata=self._client._rpc_metadata,
+            **kwargs,
         )
 
         while True:

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -269,13 +269,21 @@ class DocumentReference(BaseDocumentReference):
         write_results = batch.commit()
         return _first_write_result(write_results)
 
-    def delete(self, option: _helpers.WriteOption = None) -> Any:
+    def delete(
+        self,
+        option: _helpers.WriteOption = None,
+        retry: retries.Retry = None,
+        timeout: float = None,
+    ) -> Any:
         """Delete the current document in the Firestore database.
 
         Args:
             option (Optional[:class:`~google.cloud.firestore_v1.client.WriteOption`]):
                 A write option to make assertions / preconditions on the server
                 state of the document before applying changes.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`google.protobuf.timestamp_pb2.Timestamp`:
@@ -285,6 +293,7 @@ class DocumentReference(BaseDocumentReference):
             still return the time that the request was received by the server.
         """
         write_pb = _helpers.pb_for_delete(self._document_path, option)
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
         commit_response = self._client._firestore_api.commit(
             request={
                 "database": self._client._database_string,
@@ -292,6 +301,7 @@ class DocumentReference(BaseDocumentReference):
                 "transaction": None,
             },
             metadata=self._client._rpc_metadata,
+            **kwargs,
         )
 
         return commit_response.commit_time

--- a/google/cloud/firestore_v1/document.py
+++ b/google/cloud/firestore_v1/document.py
@@ -69,12 +69,17 @@ class DocumentReference(BaseDocumentReference):
 
         return kwargs
 
-    def create(self, document_data) -> Any:
+    def create(
+        self, document_data, retry: retries.Retry = None, timeout: float = None,
+    ) -> Any:
         """Create the current document in the Firestore database.
 
         Args:
             document_data (dict): Property names and values to use for
                 creating a document.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             :class:`~google.cloud.firestore_v1.types.WriteResult`:
@@ -87,7 +92,8 @@ class DocumentReference(BaseDocumentReference):
         """
         batch = self._client.batch()
         batch.create(self, document_data)
-        write_results = batch.commit()
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        write_results = batch.commit(**kwargs)
         return _first_write_result(write_results)
 
     def set(self, document_data: dict, merge: bool = False) -> Any:

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -19,6 +19,7 @@ a :class:`~google.cloud.firestore_v1.collection.Collection` and that can be
 a more common way to create a query than direct usage of the constructor.
 """
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_query import (
@@ -120,7 +121,10 @@ class Query(BaseQuery):
         )
 
     def get(
-        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        transaction=None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> list:
         """Read the documents in the collection that match this query.
 
@@ -163,7 +167,10 @@ class Query(BaseQuery):
         return list(result)
 
     def stream(
-        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+        self,
+        transaction=None,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Generator[document.DocumentSnapshot, Any, None]:
         """Read the documents in the collection that match this query.
 
@@ -292,7 +299,10 @@ class CollectionGroup(Query, BaseCollectionGroup):
         return Query
 
     def get_partitions(
-        self, partition_count, retry: retries.Retry = None, timeout: float = None
+        self,
+        partition_count,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Generator[QueryPartition, None, None]:
         """Partition a query for parallelization.
 

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -135,8 +135,9 @@ class Query(BaseQuery):
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Returns:
             list: The documents in the collection that match this query.
@@ -186,8 +187,9 @@ class Query(BaseQuery):
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             :class:`~google.cloud.firestore_v1.document.DocumentSnapshot`:
@@ -303,8 +305,9 @@ class CollectionGroup(Query, BaseCollectionGroup):
                 number must be strictly positive. The actual number of partitions
                 returned may be fewer.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
         """
         request, kwargs = self._prep_get_partitions(partition_count, retry, timeout)
 

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -200,13 +200,7 @@ class Query(BaseQuery):
 
         parent_path, expected_prefix = self._parent._parent_info()
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         response_iterator = self._client._firestore_api.run_query(
             request={
@@ -330,13 +324,7 @@ class CollectionGroup(Query, BaseCollectionGroup):
 
         parent_path, expected_prefix = self._parent._parent_info()
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         pager = self._client._firestore_api.partition_query(
             request={

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -118,7 +118,9 @@ class Query(BaseQuery):
             all_descendants=all_descendants,
         )
 
-    def get(self, transaction=None) -> list:
+    def get(
+        self, transaction=None, retry: retries.Retry = None, timeout: float = None,
+    ) -> list:
         """Read the documents in the collection that match this query.
 
         This sends a ``RunQuery`` RPC and returns a list of documents
@@ -128,9 +130,12 @@ class Query(BaseQuery):
             transaction
                 (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
-        If a ``transaction`` is used and it already has write operations
-        added, this method cannot be used (i.e. read-after-write is not
-        allowed).
+                If a ``transaction`` is used and it already has write operations
+                added, this method cannot be used (i.e. read-after-write is not
+                allowed).
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
 
         Returns:
             list: The documents in the collection that match this query.
@@ -149,7 +154,7 @@ class Query(BaseQuery):
                 )
             self._limit_to_last = False
 
-        result = self.stream(transaction=transaction)
+        result = self.stream(transaction=transaction, retry=retry, timeout=timeout)
         if is_limited_to_last:
             result = reversed(list(result))
 

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -169,19 +169,25 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         kwargs = self._make_retry_timeout_kwargs(retry, timeout)
         return self._client.get_all(references, transaction=self, **kwargs)
 
-    def get(self, ref_or_query) -> Any:
+    def get(
+        self, ref_or_query, retry: retries.Retry = None, timeout: float = None
+    ) -> Any:
         """
         Retrieve a document or a query result from the database.
         Args:
-            ref_or_query The document references or query object to return.
+            ref_or_query: The document references or query object to return.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.
         """
+        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
         if isinstance(ref_or_query, DocumentReference):
-            return self._client.get_all([ref_or_query], transaction=self)
+            return self._client.get_all([ref_or_query], transaction=self, **kwargs)
         elif isinstance(ref_or_query, Query):
-            return ref_or_query.stream(transaction=self)
+            return ref_or_query.stream(transaction=self, **kwargs)
         else:
             raise ValueError(
                 'Value for argument "ref_or_query" must be a DocumentReference or a Query.'

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -37,6 +37,7 @@ from google.cloud.firestore_v1.base_transaction import (
 from google.api_core import exceptions  # type: ignore
 from google.cloud.firestore_v1 import batch
 from google.cloud.firestore_v1.document import DocumentReference
+from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1.query import Query
 from typing import Any, Callable, Optional
 
@@ -138,18 +139,6 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         self._clean_up()
         return list(commit_response.write_results)
 
-    @staticmethod
-    def _make_retry_timeout_kwargs(retry, timeout):
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
-        return kwargs
-
     def get_all(
         self, references: list, retry: retries.Retry = None, timeout: float = None
     ) -> Any:
@@ -166,7 +155,7 @@ class Transaction(batch.WriteBatch, BaseTransaction):
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.
         """
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         return self._client.get_all(references, transaction=self, **kwargs)
 
     def get(
@@ -184,7 +173,7 @@ class Transaction(batch.WriteBatch, BaseTransaction):
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.
         """
-        kwargs = self._make_retry_timeout_kwargs(retry, timeout)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         if isinstance(ref_or_query, DocumentReference):
             return self._client.get_all([ref_or_query], transaction=self, **kwargs)
         elif isinstance(ref_or_query, Query):

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -172,13 +172,14 @@ class Transaction(batch.WriteBatch, BaseTransaction):
     def get(
         self, ref_or_query, retry: retries.Retry = None, timeout: float = None
     ) -> Any:
-        """
-        Retrieve a document or a query result from the database.
+        """Retrieve a document or a query result from the database.
+
         Args:
             ref_or_query: The document references or query object to return.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
+
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
             query, or :data:`None` if the document does not exist.

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -148,8 +148,9 @@ class Transaction(batch.WriteBatch, BaseTransaction):
             references (List[.DocumentReference, ...]): Iterable of document
                 references to be retrieved.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the
@@ -166,8 +167,9 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         Args:
             ref_or_query: The document references or query object to return.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
-            timeout (float): The timeout for this request.
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
 
         Yields:
             .DocumentSnapshot: The next document snapshot that fulfills the

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -18,6 +18,7 @@
 import random
 import time
 
+from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
 from google.cloud.firestore_v1.base_transaction import (
@@ -140,7 +141,10 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         return list(commit_response.write_results)
 
     def get_all(
-        self, references: list, retry: retries.Retry = None, timeout: float = None
+        self,
+        references: list,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Any:
         """Retrieves multiple documents from Firestore.
 
@@ -160,7 +164,10 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         return self._client.get_all(references, transaction=self, **kwargs)
 
     def get(
-        self, ref_or_query, retry: retries.Retry = None, timeout: float = None
+        self,
+        ref_or_query,
+        retry: retries.Retry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
     ) -> Any:
         """Retrieve a document or a query result from the database.
 

--- a/tests/unit/v1/test__helpers.py
+++ b/tests/unit/v1/test__helpers.py
@@ -2173,7 +2173,7 @@ class Test_pbs_for_update(unittest.TestCase):
         self._helper(current_document=precondition)
 
     def test_with_exists_option(self):
-        from google.cloud.firestore_v1.client import _helpers
+        from google.cloud.firestore_v1 import _helpers
 
         option = _helpers.ExistsOption(False)
         self._helper(option=option)
@@ -2385,6 +2385,42 @@ class TestExistsOption(unittest.TestCase):
             self.assertIsNone(ret_val)
             expected_doc = common.Precondition(exists=exists)
             self.assertEqual(write_pb.current_document, expected_doc)
+
+
+class Test_make_retry_timeout_kwargs(unittest.TestCase):
+    @staticmethod
+    def _call_fut(retry, timeout):
+        from google.cloud.firestore_v1._helpers import make_retry_timeout_kwargs
+
+        return make_retry_timeout_kwargs(retry, timeout)
+
+    def test_default(self):
+        kwargs = self._call_fut(None, None)
+        expected = {}
+        self.assertEqual(kwargs, expected)
+
+    def test_retry_only(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        kwargs = self._call_fut(retry, None)
+        expected = {"retry": retry}
+        self.assertEqual(kwargs, expected)
+
+    def test_timeout_only(self):
+        timeout = 123.0
+        kwargs = self._call_fut(None, timeout)
+        expected = {"timeout": timeout}
+        self.assertEqual(kwargs, expected)
+
+    def test_retry_and_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        kwargs = self._call_fut(retry, timeout)
+        expected = {"retry": retry, "timeout": timeout}
+        self.assertEqual(kwargs, expected)
 
 
 def _value_pb(**kwargs):

--- a/tests/unit/v1/test__helpers.py
+++ b/tests/unit/v1/test__helpers.py
@@ -2402,8 +2402,6 @@ class Test_make_retry_timeout_kwargs(unittest.TestCase):
         self.assertEqual(kwargs, expected)
 
     def test_retry_None(self):
-        from google.api_core.retry import Retry
-
         kwargs = self._call_fut(None, None)
         expected = {"retry": None}
         self.assertEqual(kwargs, expected)

--- a/tests/unit/v1/test__helpers.py
+++ b/tests/unit/v1/test__helpers.py
@@ -2395,8 +2395,17 @@ class Test_make_retry_timeout_kwargs(unittest.TestCase):
         return make_retry_timeout_kwargs(retry, timeout)
 
     def test_default(self):
-        kwargs = self._call_fut(None, None)
+        from google.api_core.gapic_v1.method import DEFAULT
+
+        kwargs = self._call_fut(DEFAULT, None)
         expected = {}
+        self.assertEqual(kwargs, expected)
+
+    def test_retry_None(self):
+        from google.api_core.retry import Retry
+
+        kwargs = self._call_fut(None, None)
+        expected = {"retry": None}
         self.assertEqual(kwargs, expected)
 
     def test_retry_only(self):
@@ -2408,8 +2417,10 @@ class Test_make_retry_timeout_kwargs(unittest.TestCase):
         self.assertEqual(kwargs, expected)
 
     def test_timeout_only(self):
+        from google.api_core.gapic_v1.method import DEFAULT
+
         timeout = 123.0
-        kwargs = self._call_fut(None, timeout)
+        kwargs = self._call_fut(DEFAULT, timeout)
         expected = {"timeout": timeout}
         self.assertEqual(kwargs, expected)
 

--- a/tests/unit/v1/test_async_client.py
+++ b/tests/unit/v1/test_async_client.py
@@ -131,11 +131,11 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
 
     def test_collection_group(self):
         client = self._make_default_one()
-        query = client.collection_group("collectionId").where("foo", "==", u"bar")
+        query = client.collection_group("collectionId").where("foo", "==", "bar")
 
         self.assertTrue(query._all_descendants)
         self.assertEqual(query._field_filters[0].field.field_path, "foo")
-        self.assertEqual(query._field_filters[0].value.string_value, u"bar")
+        self.assertEqual(query._field_filters[0].value.string_value, "bar")
         self.assertEqual(
             query._field_filters[0].op, query._field_filters[0].Operator.EQUAL
         )
@@ -195,8 +195,7 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
         self.assertIs(document2._client, client)
         self.assertIsInstance(document2, AsyncDocumentReference)
 
-    @pytest.mark.asyncio
-    async def test_collections(self):
+    async def _collections_helper(self, retry=None, timeout=None):
         from google.api_core.page_iterator import Iterator
         from google.api_core.page_iterator import Page
         from google.cloud.firestore_v1.async_collection import AsyncCollectionReference
@@ -220,10 +219,18 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
                     page, self._pages = self._pages[0], self._pages[1:]
                     return Page(self, page, self.item_to_value)
 
+        kwargs = {}
+
+        if retry is not None:
+            kwargs["retry"] = retry
+
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
         iterator = _Iterator(pages=[collection_ids])
         firestore_api.list_collection_ids.return_value = iterator
 
-        collections = [c async for c in client.collections()]
+        collections = [c async for c in client.collections(**kwargs)]
 
         self.assertEqual(len(collections), len(collection_ids))
         for collection, collection_id in zip(collections, collection_ids):
@@ -233,10 +240,22 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
 
         base_path = client._database_string + "/documents"
         firestore_api.list_collection_ids.assert_called_once_with(
-            request={"parent": base_path}, metadata=client._rpc_metadata
+            request={"parent": base_path}, metadata=client._rpc_metadata, **kwargs,
         )
 
-    async def _get_all_helper(self, client, references, document_pbs, **kwargs):
+    @pytest.mark.asyncio
+    async def test_collections(self):
+        await self._collections_helper()
+
+    @pytest.mark.asyncio
+    async def test_collections_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        await self._collections_helper(retry=retry, timeout=timeout)
+
+    async def _invoke_get_all(self, client, references, document_pbs, **kwargs):
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = AsyncMock(spec=["batch_get_documents"])
         response_iterator = AsyncIter(document_pbs)
@@ -265,145 +284,121 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
 
         return client, document1, document2, response1, response2
 
-    @pytest.mark.asyncio
-    async def test_get_all(self):
+    async def _get_all_helper(
+        self, num_snapshots=2, txn_id=None, retry=None, timeout=None
+    ):
         from google.cloud.firestore_v1.types import common
         from google.cloud.firestore_v1.async_document import DocumentSnapshot
 
-        data1 = {"a": u"cheese"}
+        client = self._make_default_one()
+
+        data1 = {"a": "cheese"}
+        document1 = client.document("pineapple", "lamp1")
+        document_pb1, read_time = _doc_get_info(document1._document_path, data1)
+        response1 = _make_batch_response(found=document_pb1, read_time=read_time)
+
         data2 = {"b": True, "c": 18}
-        info = self._info_for_get_all(data1, data2)
-        client, document1, document2, response1, response2 = info
+        document2 = client.document("pineapple", "lamp2")
+        document, read_time = _doc_get_info(document2._document_path, data2)
+        response2 = _make_batch_response(found=document, read_time=read_time)
 
-        # Exercise the mocked ``batch_get_documents``.
-        field_paths = ["a", "b"]
-        snapshots = await self._get_all_helper(
-            client,
-            [document1, document2],
-            [response1, response2],
-            field_paths=field_paths,
+        document3 = client.document("pineapple", "lamp3")
+        response3 = _make_batch_response(missing=document3._document_path)
+
+        expected_data = [data1, data2, None][:num_snapshots]
+        documents = [document1, document2, document3][:num_snapshots]
+        responses = [response1, response2, response3][:num_snapshots]
+        field_paths = [
+            field_path for field_path in ["a", "b", None][:num_snapshots] if field_path
+        ]
+
+        kwargs = {}
+
+        if retry is not None:
+            kwargs["retry"] = retry
+
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
+        if txn_id is not None:
+            transaction = client.transaction()
+            transaction._id = txn_id
+            kwargs["transaction"] = transaction
+
+        snapshots = await self._invoke_get_all(
+            client, documents, responses, field_paths=field_paths, **kwargs,
         )
-        self.assertEqual(len(snapshots), 2)
 
-        snapshot1 = snapshots[0]
-        self.assertIsInstance(snapshot1, DocumentSnapshot)
-        self.assertIs(snapshot1._reference, document1)
-        self.assertEqual(snapshot1._data, data1)
+        self.assertEqual(len(snapshots), num_snapshots)
 
-        snapshot2 = snapshots[1]
-        self.assertIsInstance(snapshot2, DocumentSnapshot)
-        self.assertIs(snapshot2._reference, document2)
-        self.assertEqual(snapshot2._data, data2)
+        for data, document, snapshot in zip(expected_data, documents, snapshots):
+            self.assertIsInstance(snapshot, DocumentSnapshot)
+            self.assertIs(snapshot._reference, document)
+            if data is None:
+                self.assertFalse(snapshot.exists)
+            else:
+                self.assertEqual(snapshot._data, data)
 
         # Verify the call to the mock.
-        doc_paths = [document1._document_path, document2._document_path]
+        doc_paths = [document._document_path for document in documents]
         mask = common.DocumentMask(field_paths=field_paths)
+
+        kwargs.pop("transaction", None)
+
         client._firestore_api.batch_get_documents.assert_called_once_with(
             request={
                 "database": client._database_string,
                 "documents": doc_paths,
                 "mask": mask,
-                "transaction": None,
-            },
-            metadata=client._rpc_metadata,
-        )
-
-    @pytest.mark.asyncio
-    async def test_get_all_with_transaction(self):
-        from google.cloud.firestore_v1.async_document import DocumentSnapshot
-
-        data = {"so-much": 484}
-        info = self._info_for_get_all(data, {})
-        client, document, _, response, _ = info
-        transaction = client.transaction()
-        txn_id = b"the-man-is-non-stop"
-        transaction._id = txn_id
-
-        # Exercise the mocked ``batch_get_documents``.
-        snapshots = await self._get_all_helper(
-            client, [document], [response], transaction=transaction
-        )
-        self.assertEqual(len(snapshots), 1)
-
-        snapshot = snapshots[0]
-        self.assertIsInstance(snapshot, DocumentSnapshot)
-        self.assertIs(snapshot._reference, document)
-        self.assertEqual(snapshot._data, data)
-
-        # Verify the call to the mock.
-        doc_paths = [document._document_path]
-        client._firestore_api.batch_get_documents.assert_called_once_with(
-            request={
-                "database": client._database_string,
-                "documents": doc_paths,
-                "mask": None,
                 "transaction": txn_id,
             },
             metadata=client._rpc_metadata,
+            **kwargs,
         )
+
+    @pytest.mark.asyncio
+    async def test_get_all(self):
+        await self._get_all_helper()
+
+    @pytest.mark.asyncio
+    async def test_get_all_with_transaction(self):
+        txn_id = b"the-man-is-non-stop"
+        await self._get_all_helper(num_snapshots=1, txn_id=txn_id)
+
+    @pytest.mark.asyncio
+    async def test_get_all_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        await self._get_all_helper(retry=retry, timeout=timeout)
+
+    @pytest.mark.asyncio
+    async def test_get_all_wrong_order(self):
+        await self._get_all_helper(num_snapshots=3)
 
     @pytest.mark.asyncio
     async def test_get_all_unknown_result(self):
         from google.cloud.firestore_v1.base_client import _BAD_DOC_TEMPLATE
 
-        info = self._info_for_get_all({"z": 28.5}, {})
-        client, document, _, _, response = info
+        client = self._make_default_one()
+
+        document1 = client.document("pineapple", "lamp1")
+
+        data = {"z": 28.5}
+        wrong_document = client.document("pineapple", "lamp2")
+        document_pb, read_time = _doc_get_info(wrong_document._document_path, data)
+        response = _make_batch_response(found=document_pb, read_time=read_time)
 
         # Exercise the mocked ``batch_get_documents``.
         with self.assertRaises(ValueError) as exc_info:
-            await self._get_all_helper(client, [document], [response])
+            await self._invoke_get_all(client, [document1], [response])
 
         err_msg = _BAD_DOC_TEMPLATE.format(response.found.name)
         self.assertEqual(exc_info.exception.args, (err_msg,))
 
         # Verify the call to the mock.
-        doc_paths = [document._document_path]
-        client._firestore_api.batch_get_documents.assert_called_once_with(
-            request={
-                "database": client._database_string,
-                "documents": doc_paths,
-                "mask": None,
-                "transaction": None,
-            },
-            metadata=client._rpc_metadata,
-        )
-
-    @pytest.mark.asyncio
-    async def test_get_all_wrong_order(self):
-        from google.cloud.firestore_v1.async_document import DocumentSnapshot
-
-        data1 = {"up": 10}
-        data2 = {"down": -10}
-        info = self._info_for_get_all(data1, data2)
-        client, document1, document2, response1, response2 = info
-        document3 = client.document("pineapple", "lamp3")
-        response3 = _make_batch_response(missing=document3._document_path)
-
-        # Exercise the mocked ``batch_get_documents``.
-        snapshots = await self._get_all_helper(
-            client, [document1, document2, document3], [response2, response1, response3]
-        )
-
-        self.assertEqual(len(snapshots), 3)
-
-        snapshot1 = snapshots[0]
-        self.assertIsInstance(snapshot1, DocumentSnapshot)
-        self.assertIs(snapshot1._reference, document2)
-        self.assertEqual(snapshot1._data, data2)
-
-        snapshot2 = snapshots[1]
-        self.assertIsInstance(snapshot2, DocumentSnapshot)
-        self.assertIs(snapshot2._reference, document1)
-        self.assertEqual(snapshot2._data, data1)
-
-        self.assertFalse(snapshots[2].exists)
-
-        # Verify the call to the mock.
-        doc_paths = [
-            document1._document_path,
-            document2._document_path,
-            document3._document_path,
-        ]
+        doc_paths = [document1._document_path]
         client._firestore_api.batch_get_documents.assert_called_once_with(
             request={
                 "database": client._database_string,

--- a/tests/unit/v1/test_async_client.py
+++ b/tests/unit/v1/test_async_client.py
@@ -199,6 +199,7 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
         from google.api_core.page_iterator import Iterator
         from google.api_core.page_iterator import Page
         from google.cloud.firestore_v1.async_collection import AsyncCollectionReference
+        from google.cloud.firestore_v1 import _helpers
 
         collection_ids = ["users", "projects"]
         client = self._make_default_one()
@@ -219,14 +220,7 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
                     page, self._pages = self._pages[0], self._pages[1:]
                     return Page(self, page, self.item_to_value)
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         iterator = _Iterator(pages=[collection_ids])
         firestore_api.list_collection_ids.return_value = iterator
 
@@ -287,6 +281,7 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
     async def _get_all_helper(
         self, num_snapshots=2, txn_id=None, retry=None, timeout=None
     ):
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.types import common
         from google.cloud.firestore_v1.async_document import DocumentSnapshot
 
@@ -311,14 +306,7 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
         field_paths = [
             field_path for field_path in ["a", "b", None][:num_snapshots] if field_path
         ]
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         if txn_id is not None:
             transaction = client.transaction()

--- a/tests/unit/v1/test_async_transaction.py
+++ b/tests/unit/v1/test_async_transaction.py
@@ -279,37 +279,83 @@ class TestAsyncTransaction(aiounittest.AsyncTestCase):
             metadata=client._rpc_metadata,
         )
 
-    @pytest.mark.asyncio
-    async def test_get_all(self):
+    async def _get_all_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
+
         client = AsyncMock(spec=["get_all"])
         transaction = self._make_one(client)
         ref1, ref2 = mock.Mock(), mock.Mock()
-        result = await transaction.get_all([ref1, ref2])
-        client.get_all.assert_called_once_with([ref1, ref2], transaction=transaction)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        result = await transaction.get_all([ref1, ref2], **kwargs)
+
+        client.get_all.assert_called_once_with(
+            [ref1, ref2], transaction=transaction, **kwargs,
+        )
         self.assertIs(result, client.get_all.return_value)
 
     @pytest.mark.asyncio
-    async def test_get_document_ref(self):
+    async def test_get_all(self):
+        await self._get_all_helper()
+
+    @pytest.mark.asyncio
+    async def test_get_all_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        await self._get_all_helper(retry=retry, timeout=timeout)
+
+    async def _get_w_document_ref_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1.async_document import AsyncDocumentReference
+        from google.cloud.firestore_v1 import _helpers
 
         client = AsyncMock(spec=["get_all"])
         transaction = self._make_one(client)
         ref = AsyncDocumentReference("documents", "doc-id")
-        result = await transaction.get(ref)
-        client.get_all.assert_called_once_with([ref], transaction=transaction)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        result = await transaction.get(ref, **kwargs)
+
+        client.get_all.assert_called_once_with([ref], transaction=transaction, **kwargs)
         self.assertIs(result, client.get_all.return_value)
 
     @pytest.mark.asyncio
-    async def test_get_w_query(self):
+    async def test_get_w_document_ref(self):
+        await self._get_w_document_ref_helper()
+
+    @pytest.mark.asyncio
+    async def test_get_w_document_ref_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        await self._get_w_document_ref_helper()
+
+    async def _get_w_query_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1.async_query import AsyncQuery
+        from google.cloud.firestore_v1 import _helpers
 
         client = AsyncMock(spec=[])
         transaction = self._make_one(client)
         query = AsyncQuery(parent=AsyncMock(spec=[]))
         query.stream = AsyncMock()
-        result = await transaction.get(query)
-        query.stream.assert_called_once_with(transaction=transaction)
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        result = await transaction.get(query, **kwargs,)
+
+        query.stream.assert_called_once_with(
+            transaction=transaction, **kwargs,
+        )
         self.assertIs(result, query.stream.return_value)
+
+    @pytest.mark.asyncio
+    async def test_get_w_query(self):
+        await self._get_w_query_helper()
+
+    @pytest.mark.asyncio
+    async def test_get_w_query_w_retry_timeout(self):
+        await self._get_w_query_helper()
 
     @pytest.mark.asyncio
     async def test_get_failure(self):

--- a/tests/unit/v1/test_async_transaction.py
+++ b/tests/unit/v1/test_async_transaction.py
@@ -330,7 +330,7 @@ class TestAsyncTransaction(aiounittest.AsyncTestCase):
 
         retry = Retry(predicate=object())
         timeout = 123.0
-        await self._get_w_document_ref_helper()
+        await self._get_w_document_ref_helper(retry=retry, timeout=timeout)
 
     async def _get_w_query_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1.async_query import AsyncQuery

--- a/tests/unit/v1/test_batch.py
+++ b/tests/unit/v1/test_batch.py
@@ -37,6 +37,7 @@ class TestWriteBatch(unittest.TestCase):
 
     def _commit_helper(self, retry=None, timeout=None):
         from google.protobuf import timestamp_pb2
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.types import firestore
         from google.cloud.firestore_v1.types import write
 
@@ -48,14 +49,7 @@ class TestWriteBatch(unittest.TestCase):
             commit_time=timestamp,
         )
         firestore_api.commit.return_value = commit_response
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         # Attach the fake GAPIC to a real client.
         client = _make_client("grand")

--- a/tests/unit/v1/test_client.py
+++ b/tests/unit/v1/test_client.py
@@ -273,9 +273,7 @@ class TestClient(unittest.TestCase):
 
         return client, document1, document2, response1, response2
 
-    def _get_all_helper(
-        self, num_snapshots=2, txn_id=None, retry=None, timeout=None
-    ):
+    def _get_all_helper(self, num_snapshots=2, txn_id=None, retry=None, timeout=None):
         from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.types import common
         from google.cloud.firestore_v1.async_document import DocumentSnapshot

--- a/tests/unit/v1/test_client.py
+++ b/tests/unit/v1/test_client.py
@@ -194,6 +194,7 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(document2, DocumentReference)
 
     def _collections_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
         from google.api_core.page_iterator import Iterator
         from google.api_core.page_iterator import Page
         from google.cloud.firestore_v1.collection import CollectionReference
@@ -216,14 +217,7 @@ class TestClient(unittest.TestCase):
                     page, self._pages = self._pages[0], self._pages[1:]
                     return Page(self, page, self.item_to_value)
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         iterator = _Iterator(pages=[collection_ids])
         firestore_api.list_collection_ids.return_value = iterator
 

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -287,6 +287,23 @@ class TestCollectionReference(unittest.TestCase):
         query_instance.get.assert_called_once_with(transaction=None)
 
     @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
+    def test_get_w_retry_timeout(self, query_class):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        collection = self._make_one("collection")
+        get_response = collection.get(retry=retry, timeout=timeout)
+
+        query_class.assert_called_once_with(collection)
+        query_instance = query_class.return_value
+
+        self.assertIs(get_response, query_instance.get.return_value)
+        query_instance.get.assert_called_once_with(
+            transaction=None, retry=retry, timeout=timeout,
+        )
+
+    @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
     def test_get_with_transaction(self, query_class):
 
         collection = self._make_one("collection")

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -99,7 +99,7 @@ class TestCollectionReference(unittest.TestCase):
         # sure transforms during adds work.
         document_data = {"been": "here", "now": SERVER_TIMESTAMP}
 
-        patch = mock.patch("google.cloud.firestore_v1.collection._auto_id")
+        patch = mock.patch("google.cloud.firestore_v1.base_collection._auto_id")
         random_doc_id = "DEADBEEF"
         with patch as patched:
             patched.return_value = random_doc_id

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -140,6 +140,7 @@ class TestCollectionReference(unittest.TestCase):
 
     def _add_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1.document import DocumentReference
+        from google.cloud.firestore_v1 import _helpers
 
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
@@ -162,14 +163,7 @@ class TestCollectionReference(unittest.TestCase):
         document_data = {"zorp": 208.75, "i-did-not": b"know that"}
         doc_id = "child"
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
         update_time, document_ref = collection.add(
             document_data, document_id=doc_id, **kwargs
         )
@@ -202,6 +196,7 @@ class TestCollectionReference(unittest.TestCase):
         self._add_helper(retry=retry, timeout=timeout)
 
     def _list_documents_helper(self, page_size=None, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
         from google.api_core.page_iterator import Iterator
         from google.api_core.page_iterator import Page
         from google.cloud.firestore_v1.document import DocumentReference
@@ -229,14 +224,7 @@ class TestCollectionReference(unittest.TestCase):
         api_client.list_documents.return_value = iterator
         client._firestore_api_internal = api_client
         collection = self._make_one("collection", client=client)
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         if page_size is not None:
             documents = list(collection.list_documents(page_size=page_size, **kwargs))

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -201,7 +201,7 @@ class TestCollectionReference(unittest.TestCase):
         timeout = 123.0
         self._add_helper(retry=retry, timeout=timeout)
 
-    def _list_documents_helper(self, page_size=None):
+    def _list_documents_helper(self, page_size=None, retry=None, timeout=None):
         from google.api_core.page_iterator import Iterator
         from google.api_core.page_iterator import Page
         from google.cloud.firestore_v1.document import DocumentReference
@@ -230,10 +230,18 @@ class TestCollectionReference(unittest.TestCase):
         client._firestore_api_internal = api_client
         collection = self._make_one("collection", client=client)
 
+        kwargs = {}
+
+        if retry is not None:
+            kwargs["retry"] = retry
+
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
         if page_size is not None:
-            documents = list(collection.list_documents(page_size=page_size))
+            documents = list(collection.list_documents(page_size=page_size, **kwargs))
         else:
-            documents = list(collection.list_documents())
+            documents = list(collection.list_documents(**kwargs))
 
         # Verify the response and the mocks.
         self.assertEqual(len(documents), len(document_ids))
@@ -251,10 +259,18 @@ class TestCollectionReference(unittest.TestCase):
                 "show_missing": True,
             },
             metadata=client._rpc_metadata,
+            **kwargs,
         )
 
     def test_list_documents_wo_page_size(self):
         self._list_documents_helper()
+
+    def test_list_documents_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        self._list_documents_helper(retry=retry, timeout=timeout)
 
     def test_list_documents_w_page_size(self):
         self._list_documents_helper(page_size=25)

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -327,6 +327,22 @@ class TestCollectionReference(unittest.TestCase):
         query_instance.stream.assert_called_once_with(transaction=None)
 
     @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
+    def test_stream_w_retry_timeout(self, query_class):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        collection = self._make_one("collection")
+        stream_response = collection.stream(retry=retry, timeout=timeout)
+
+        query_class.assert_called_once_with(collection)
+        query_instance = query_class.return_value
+        self.assertIs(stream_response, query_instance.stream.return_value)
+        query_instance.stream.assert_called_once_with(
+            transaction=None, retry=retry, timeout=timeout,
+        )
+
+    @mock.patch("google.cloud.firestore_v1.query.Query", autospec=True)
     def test_stream_with_transaction(self, query_class):
         collection = self._make_one("collection")
         transaction = mock.sentinel.txn

--- a/tests/unit/v1/test_document.py
+++ b/tests/unit/v1/test_document.py
@@ -70,6 +70,7 @@ class TestDocumentReference(unittest.TestCase):
         )
 
     def _create_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock()
         firestore_api.commit.mock_add_spec(spec=["commit"])
@@ -82,14 +83,7 @@ class TestDocumentReference(unittest.TestCase):
         # Actually make a document and call create().
         document = self._make_one("foo", "twelve", client=client)
         document_data = {"hello": "goodbye", "count": 99}
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         write_result = document.create(document_data, **kwargs)
 
@@ -169,6 +163,7 @@ class TestDocumentReference(unittest.TestCase):
         return write_pbs
 
     def _set_helper(self, merge=False, retry=None, timeout=None, **option_kwargs):
+        from google.cloud.firestore_v1 import _helpers
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
         firestore_api.commit.return_value = self._make_commit_repsonse()
@@ -180,14 +175,7 @@ class TestDocumentReference(unittest.TestCase):
         # Actually make a document and call create().
         document = self._make_one("User", "Interface", client=client)
         document_data = {"And": 500, "Now": b"\xba\xaa\xaa \xba\xaa\xaa"}
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         write_result = document.set(document_data, merge, **kwargs)
 
@@ -234,6 +222,7 @@ class TestDocumentReference(unittest.TestCase):
         )
 
     def _update_helper(self, retry=None, timeout=None, **option_kwargs):
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.transforms import DELETE_FIELD
 
         # Create a minimal fake GAPIC with a dummy response.
@@ -250,14 +239,7 @@ class TestDocumentReference(unittest.TestCase):
         field_updates = collections.OrderedDict(
             (("hello", 1), ("then.do", False), ("goodbye", DELETE_FIELD))
         )
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         if option_kwargs:
             option = client.write_option(**option_kwargs)
@@ -325,6 +307,7 @@ class TestDocumentReference(unittest.TestCase):
             document.update(field_updates)
 
     def _delete_helper(self, retry=None, timeout=None, **option_kwargs):
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.types import write
 
         # Create a minimal fake GAPIC with a dummy response.
@@ -334,14 +317,7 @@ class TestDocumentReference(unittest.TestCase):
         # Attach the fake GAPIC to a real client.
         client = _make_client("donut-base")
         client._firestore_api_internal = firestore_api
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         # Actually make a document and call delete().
         document = self._make_one("where", "we-are", client=client)
@@ -392,6 +368,7 @@ class TestDocumentReference(unittest.TestCase):
         timeout=None,
     ):
         from google.api_core.exceptions import NotFound
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.types import common
         from google.cloud.firestore_v1.types import document
         from google.cloud.firestore_v1.transaction import Transaction
@@ -421,13 +398,7 @@ class TestDocumentReference(unittest.TestCase):
         else:
             transaction = None
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         snapshot = document.get(
             field_paths=field_paths, transaction=transaction, **kwargs
@@ -498,6 +469,7 @@ class TestDocumentReference(unittest.TestCase):
         from google.api_core.page_iterator import Iterator
         from google.api_core.page_iterator import Page
         from google.cloud.firestore_v1.collection import CollectionReference
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.services.firestore.client import FirestoreClient
 
         # TODO(microgen): https://github.com/googleapis/gapic-generator-python/issues/516
@@ -519,14 +491,7 @@ class TestDocumentReference(unittest.TestCase):
 
         client = _make_client()
         client._firestore_api_internal = api_client
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         # Actually make a document and call delete().
         document = self._make_one("where", "we-are", client=client)

--- a/tests/unit/v1/test_document.py
+++ b/tests/unit/v1/test_document.py
@@ -71,6 +71,7 @@ class TestDocumentReference(unittest.TestCase):
 
     def _create_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1 import _helpers
+
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock()
         firestore_api.commit.mock_add_spec(spec=["commit"])
@@ -164,6 +165,7 @@ class TestDocumentReference(unittest.TestCase):
 
     def _set_helper(self, merge=False, retry=None, timeout=None, **option_kwargs):
         from google.cloud.firestore_v1 import _helpers
+
         # Create a minimal fake GAPIC with a dummy response.
         firestore_api = mock.Mock(spec=["commit"])
         firestore_api.commit.return_value = self._make_commit_repsonse()

--- a/tests/unit/v1/test_query.py
+++ b/tests/unit/v1/test_query.py
@@ -160,6 +160,7 @@ class TestQuery(unittest.TestCase):
 
     def _stream_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1 import _helpers
+
         # Create a minimal fake GAPIC.
         firestore_api = mock.Mock(spec=["run_query"])
 

--- a/tests/unit/v1/test_query.py
+++ b/tests/unit/v1/test_query.py
@@ -47,6 +47,8 @@ class TestQuery(unittest.TestCase):
         self.assertFalse(query._all_descendants)
 
     def _get_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
+
         # Create a minimal fake GAPIC.
         firestore_api = mock.Mock(spec=["run_query"])
 
@@ -63,20 +65,11 @@ class TestQuery(unittest.TestCase):
         data = {"snooze": 10}
 
         response_pb = _make_query_response(name=name, data=data)
-
         firestore_api.run_query.return_value = iter([response_pb])
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         # Execute the query and check the response.
         query = self._make_one(parent)
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
         returned = query.get(**kwargs)
 
         self.assertIsInstance(returned, list)
@@ -166,6 +159,7 @@ class TestQuery(unittest.TestCase):
         )
 
     def _stream_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
         # Create a minimal fake GAPIC.
         firestore_api = mock.Mock(spec=["run_query"])
 
@@ -182,17 +176,10 @@ class TestQuery(unittest.TestCase):
         data = {"snooze": 10}
         response_pb = _make_query_response(name=name, data=data)
         firestore_api.run_query.return_value = iter([response_pb])
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         # Execute the query and check the response.
         query = self._make_one(parent)
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
 
         get_response = query.stream(**kwargs)
 
@@ -501,6 +488,8 @@ class TestCollectionGroup(unittest.TestCase):
             self._make_one(mock.sentinel.parent, all_descendants=False)
 
     def _get_partitions_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
+
         # Create a minimal fake GAPIC.
         firestore_api = mock.Mock(spec=["partition_query"])
 
@@ -519,19 +508,13 @@ class TestCollectionGroup(unittest.TestCase):
         cursor_pb1 = _make_cursor_pb(([document1], False))
         cursor_pb2 = _make_cursor_pb(([document2], False))
         firestore_api.partition_query.return_value = iter([cursor_pb1, cursor_pb2])
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         # Execute the query and check the response.
         query = self._make_one(parent)
 
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
-
         get_response = query.get_partitions(2, **kwargs)
+
         self.assertIsInstance(get_response, types.GeneratorType)
         returned = list(get_response)
         self.assertEqual(len(returned), 3)

--- a/tests/unit/v1/test_transaction.py
+++ b/tests/unit/v1/test_transaction.py
@@ -291,13 +291,34 @@ class TestTransaction(unittest.TestCase):
             metadata=client._rpc_metadata,
         )
 
-    def test_get_all(self):
+    def _get_all_helper(self, retry=None, timeout=None):
         client = mock.Mock(spec=["get_all"])
         transaction = self._make_one(client)
         ref1, ref2 = mock.Mock(), mock.Mock()
-        result = transaction.get_all([ref1, ref2])
-        client.get_all.assert_called_once_with([ref1, ref2], transaction=transaction)
+
+        kwargs = {}
+
+        if retry is not None:
+            kwargs["retry"] = retry
+
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
+        result = transaction.get_all([ref1, ref2], **kwargs)
+        client.get_all.assert_called_once_with(
+            [ref1, ref2], transaction=transaction, **kwargs,
+        )
         self.assertIs(result, client.get_all.return_value)
+
+    def test_get_all(self):
+        self._get_all_helper()
+
+    def test_get_all_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+        self._get_all_helper(retry=retry, timeout=timeout)
 
     def test_get_document_ref(self):
         from google.cloud.firestore_v1.document import DocumentReference

--- a/tests/unit/v1/test_transaction.py
+++ b/tests/unit/v1/test_transaction.py
@@ -316,7 +316,7 @@ class TestTransaction(unittest.TestCase):
         timeout = 123.0
         self._get_all_helper(retry=retry, timeout=timeout)
 
-    def _get_document_ref_helper(self, retry=None, timeout=None):
+    def _get_w_document_ref_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1.document import DocumentReference
         from google.cloud.firestore_v1 import _helpers
 
@@ -330,15 +330,15 @@ class TestTransaction(unittest.TestCase):
         self.assertIs(result, client.get_all.return_value)
         client.get_all.assert_called_once_with([ref], transaction=transaction, **kwargs)
 
-    def test_get_document_ref(self):
-        self._get_document_ref_helper()
+    def test_get_w_document_ref(self):
+        self._get_w_document_ref_helper()
 
-    def test_get_document_ref_w_retry_timeout(self):
+    def test_get_w_document_ref_w_retry_timeout(self):
         from google.api_core.retry import Retry
 
         retry = Retry(predicate=object())
         timeout = 123.0
-        self._get_document_ref_helper(retry=retry, timeout=timeout)
+        self._get_w_document_ref_helper(retry=retry, timeout=timeout)
 
     def _get_w_query_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1 import _helpers

--- a/tests/unit/v1/test_transaction.py
+++ b/tests/unit/v1/test_transaction.py
@@ -292,19 +292,15 @@ class TestTransaction(unittest.TestCase):
         )
 
     def _get_all_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
+
         client = mock.Mock(spec=["get_all"])
         transaction = self._make_one(client)
         ref1, ref2 = mock.Mock(), mock.Mock()
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         result = transaction.get_all([ref1, ref2], **kwargs)
+
         client.get_all.assert_called_once_with(
             [ref1, ref2], transaction=transaction, **kwargs,
         )
@@ -322,18 +318,12 @@ class TestTransaction(unittest.TestCase):
 
     def _get_document_ref_helper(self, retry=None, timeout=None):
         from google.cloud.firestore_v1.document import DocumentReference
+        from google.cloud.firestore_v1 import _helpers
 
         client = mock.Mock(spec=["get_all"])
         transaction = self._make_one(client)
         ref = DocumentReference("documents", "doc-id")
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         result = transaction.get(ref, **kwargs)
 
@@ -351,20 +341,14 @@ class TestTransaction(unittest.TestCase):
         self._get_document_ref_helper(retry=retry, timeout=timeout)
 
     def _get_w_query_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
         from google.cloud.firestore_v1.query import Query
 
         client = mock.Mock(spec=[])
         transaction = self._make_one(client)
         query = Query(parent=mock.Mock(spec=[]))
         query.stream = mock.MagicMock()
-
-        kwargs = {}
-
-        if retry is not None:
-            kwargs["retry"] = retry
-
-        if timeout is not None:
-            kwargs["timeout"] = timeout
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 
         result = transaction.get(query, **kwargs)
 


### PR DESCRIPTION
## Base Classes
- [x] `base_client.BaseClient.collections` (signature only)
- [x] `base_client.BaseClient.get_all` (signature only)
- [x] `base_collection.BaseCollectionReference.add` (signature only)
- [x] `base_collection.BaseCollectionReference.get` (signature only)
- [x] `base_collection.BaseCollectionReference.list_documents` (signature only)
- [x] `base_collection.BaseCollectionReference.stream` (signature only)
- [x] `base_document.BaseDocumentReference.collections` (signature only)
- [x] `base_document.BaseDocumentReference.create` (signature only)
- [x] `base_document.BaseDocumentReference.delete` (signature only)
- [x] `base_document.BaseDocumentReference.get` (signature only)
- [x] `base_document.BaseDocumentReference.set` (signature only)
- [x] `base_document.BaseDocumentReference.update` (signature only)
- [x] `base_query.BaseCollectionGroup.get_partitions` (signature only)
- [x] `base_query.BaseQuery.get` (signature only)
- [x] `base_query.BaseQuery.stream` (signature only)
- [x] `base_transaction.BaseTransaction.get` (signature only)
- [x] `base_transaction.BaseTransaction.get_all` (signature only)

## Synchronous
- [x] `batch.Batch.commit`
- [x] `client.Client.collections`
- [x] `client.Client.get_all`
- [x] `collection.Collection.add`
- [x] `collection.Collection.get`
- [x] `collection.Collection.list_documents`
- [x] `collection.Collection.stream`
- [x] `document.Document.collections`
- [x] `document.Document.create`
- [x] `document.Document.delete`
- [x] `document.Document.get`
- [x] `document.Document.set`
- [x] `document.Document.update`
- [x] `query.CollectionGroup.get_partitions`
- [x] `query.Query.get`
- [x] `query.Query.stream`
- [x] `transaction.Transaction.get`
- [x] `transaction.Transaction.get_all`

## Asynchronous
- [x] `async_batch.AsyncBatch.commit`
- [x] `async_client.AsyncClient.collections`
- [x] `async_client.AsyncClient.get_all`
- [x] `async_collection.AsyncCollection.add`
- [x] `async_collection.AsyncCollection.get`
- [x] `async_collection.AsyncCollection.list_documents`
- [x] `async_collection.AsyncCollection.stream`
- [x] `async_document.AsyncDocument.collections`
- [x] `async_document.AsyncDocument.create`
- [x] `async_document.AsyncDocument.delete`
- [x] `async_document.AsyncDocument.get`
- [x] `async_document.AsyncDocument.set`
- [x] `async_document.AsyncDocument.update`
- [x] `async_query.AsyncCollectionGroup.get_partitions`
- [x] `async_query.AsyncQuery.get`
- [x] `async_query.AsyncQuery.stream`
- [x] `async_transaction.AsyncTransaction.get`
- [x] `async_transaction.AsyncTransaction.get_all`

## Unsure
- `base_collection.BaseCollection.on_snapshot` (signature only)
- `base_document.BaseDocumentRef.on_snapshot` (signature only)
- `base_query.BaseQuery.on_snapshot` (signature only)
- `collection.Collection.on_snapshot`
- `document.Document.on_snapshot`
- `query.Query.on_snapshot`
- `watch.Watch.__init__`
- `watch.Watch.for_document`
- `watch.Watch.for_query`

Closes #221