### PR TITLE
tests: restore 100% coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -30,6 +30,8 @@ exclude_lines =
     def __repr__
     # Ignore abstract methods
     raise NotImplementedError
+    # Ignore setuptools-less fallback
+    except pkg_resources.DistributionNotFound:
 omit =
   */gapic/*.py
   */proto/*.py

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -536,17 +536,6 @@ def _get_doc_mask(field_paths: Iterable[str]) -> Optional[types.common.DocumentM
         return types.DocumentMask(field_paths=field_paths)
 
 
-def _item_to_collection_ref(iterator, item: str) -> BaseCollectionReference:
-    """Convert collection ID to collection ref.
-
-    Args:
-        iterator (google.api_core.page_iterator.GRPCIterator):
-            iterator response
-        item (str): ID of the collection
-    """
-    return iterator.client.collection(item)
-
-
 def _path_helper(path: tuple) -> Tuple[str]:
     """Standardize path into a tuple of path segments.
 

--- a/synth.py
+++ b/synth.py
@@ -191,6 +191,20 @@ except ImportError:
 """,
 )
 
+s.replace(
+    ".coveragerc",
+    """\
+    raise NotImplementedError
+omit =
+""",
+    """\
+    raise NotImplementedError
+    # Ignore setuptools-less fallback
+    except pkg_resources.DistributionNotFound:
+omit =
+""",
+)
+
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 
 s.replace(


### PR DESCRIPTION
- Ignore 'DistributionNotFound' fallbacks (only in setuptools-less installs).
- Drop unused helper (fossil from PR #225).

See #92.

release-as: 2.0.0-dev2