### PR TITLE
fix: use an insecure channel under emulation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,15 @@ API Reference
   types
   admin_client
 
+Migration Guide
+---------------
+
+See the guide below for instructions on migrating to the 2.x release of this library.
+
+.. toctree::
+    :maxdepth: 2
+
+    UPGRADING
 
 Changelog
 ---------

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -25,6 +25,7 @@ In the hierarchy of API concepts
 """
 
 import os
+import grpc
 
 import google.api_core.client_options  # type: ignore
 import google.api_core.path_template  # type: ignore
@@ -147,9 +148,7 @@ class BaseClient(ClientWithProject):
             # We need this in order to set appropriate keepalive options.
 
             if self._emulator_host is not None:
-                # TODO(microgen): this likely needs to be adapted to use insecure_channel
-                # on new generated surface.
-                channel = transport.create_channel(host=self._emulator_host)
+                channel = grpc.insecure_channel(self._emulator_host)
             else:
                 channel = transport.create_channel(
                     self._target,

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -25,7 +25,7 @@ In the hierarchy of API concepts
 """
 
 import os
-import grpc
+import grpc  # type: ignore
 
 import google.api_core.client_options  # type: ignore
 import google.api_core.path_template  # type: ignore

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ PYTYPE_VERSION = "pytype==2020.7.24"
 BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.9"
+DEFAULT_PYTHON_VERSION = "3.8"
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.9"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,6 +31,7 @@ DEFAULT_PYTHON_VERSION = "3.8"
 SYSTEM_TEST_PYTHON_VERSIONS = ["3.9"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 
+
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint(session):
     """Run linters.
@@ -97,6 +98,7 @@ def default(session):
         os.path.join("tests", "unit"),
         *session.posargs,
     )
+
 
 @nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
 def unit(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
-SYSTEM_TEST_PYTHON_VERSIONS = ["3.9"]
+SYSTEM_TEST_PYTHON_VERSIONS = ["3.8"]
 UNIT_TEST_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 
 

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -67,7 +67,7 @@ class TestBaseClient(unittest.TestCase):
         return_value=mock.sentinel.firestore_api,
     )
     @mock.patch(
-        "google.cloud.firestore_v1.services.firestore.transports.grpc.FirestoreGrpcTransport.create_channel",
+        "grpc.insecure_channel",
         autospec=True,
     )
     def test__firestore_api_property_with_emulator(
@@ -83,7 +83,7 @@ class TestBaseClient(unittest.TestCase):
         self.assertIs(firestore_api, mock_client.return_value)
         self.assertIs(firestore_api, client._firestore_api_internal)
 
-        mock_insecure_channel.assert_called_once_with(host=emulator_host)
+        mock_insecure_channel.assert_called_once_with(emulator_host)
 
         # Call again to show that it is cached, but call count is still 1.
         self.assertIs(client._firestore_api, mock_client.return_value)

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -67,8 +67,7 @@ class TestBaseClient(unittest.TestCase):
         return_value=mock.sentinel.firestore_api,
     )
     @mock.patch(
-        "grpc.insecure_channel",
-        autospec=True,
+        "grpc.insecure_channel", autospec=True,
     )
     def test__firestore_api_property_with_emulator(
         self, mock_insecure_channel, mock_client


### PR DESCRIPTION
As part of the migration to the new generator, the method for creating insecure_channels was removed. Bring back insecure channel creation for emulators.

Fixes #250