### PR TITLE
feat: support using client credentials with emulator

### DIFF
--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -174,8 +174,21 @@ class BaseClient(ClientWithProject):
 
         :return: grcp.Channel
         """
+        return grpc._channel.Channel(
+            self._emulator_host,
+            (),
+            self._local_composite_credentials()._credentials,
+            None,
+        )
 
-        credentials = google.auth.credentials.with_scopes_if_required(self._credentials, None)
+    def _local_composite_credentials(self):
+        """
+        Ceates the credentials for the local emulator channel
+        :return: grpc.ChannelCredentials
+        """
+        credentials = google.auth.credentials.with_scopes_if_required(
+            self._credentials, None
+        )
         request = google.auth.transport.requests.Request()
 
         # Create the metadata plugin for inserting the authorization header.
@@ -190,10 +203,9 @@ class BaseClient(ClientWithProject):
         local_credentials = grpc.local_channel_credentials()
 
         # Combine the local credentials and the authorization credentials.
-        composite_credentials = grpc.composite_channel_credentials(local_credentials, google_auth_credentials)
-
-        return grpc._channel.Channel(self._emulator_host, (), composite_credentials._credentials, None)
-
+        return grpc.composite_channel_credentials(
+            local_credentials, google_auth_credentials
+        )
 
     def _target_helper(self, client_class) -> str:
         """Return the target (where the API is).

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -148,7 +148,7 @@ class BaseClient(ClientWithProject):
             # We need this in order to set appropriate keepalive options.
 
             if self._emulator_host is not None:
-                channel = grpc.insecure_channel(self._emulator_host)
+                channel = self._emulator_channel()
             else:
                 channel = transport.create_channel(
                     self._target,
@@ -164,6 +164,36 @@ class BaseClient(ClientWithProject):
             client_module._client_info = self._client_info
 
         return self._firestore_api_internal
+
+    def _emulator_channel(self):
+        """
+        Creates a channel using self._credentials in a similar way to grpc.secure_channel but
+        using grpc.local_channel_credentials() rather than grpc.ssh_channel_credentials() to allow easy connection
+        to a local firestore emulator. This allows local testing of firestore rules if the credentials have been
+        created from a signed custom token.
+
+        :return: grcp.Channel
+        """
+
+        credentials = google.auth.credentials.with_scopes_if_required(self._credentials, None)
+        request = google.auth.transport.requests.Request()
+
+        # Create the metadata plugin for inserting the authorization header.
+        metadata_plugin = google.auth.transport.grpc.AuthMetadataPlugin(
+            credentials, request
+        )
+
+        # Create a set of grpc.CallCredentials using the metadata plugin.
+        google_auth_credentials = grpc.metadata_call_credentials(metadata_plugin)
+
+        # Using the local_credentials to allow connection to emulator
+        local_credentials = grpc.local_channel_credentials()
+
+        # Combine the local credentials and the authorization credentials.
+        composite_credentials = grpc.composite_channel_credentials(local_credentials, google_auth_credentials)
+
+        return grpc._channel.Channel(self._emulator_host, (), composite_credentials._credentials, None)
+
 
     def _target_helper(self, client_class) -> str:
         """Return the target (where the API is).

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -18,6 +18,7 @@ import unittest
 import mock
 
 
+
 class TestBaseClient(unittest.TestCase):
 
     PROJECT = "my-prahjekt"
@@ -67,10 +68,11 @@ class TestBaseClient(unittest.TestCase):
         return_value=mock.sentinel.firestore_api,
     )
     @mock.patch(
-        "grpc.insecure_channel", autospec=True,
+        "google.cloud.firestore_v1.base_client.BaseClient._emulator_channel",
+        autospec=True
     )
     def test__firestore_api_property_with_emulator(
-        self, mock_insecure_channel, mock_client
+        self, mock_emulator_channel, mock_client
     ):
         emulator_host = "localhost:8081"
         with mock.patch("os.getenv") as getenv:
@@ -82,7 +84,7 @@ class TestBaseClient(unittest.TestCase):
         self.assertIs(firestore_api, mock_client.return_value)
         self.assertIs(firestore_api, client._firestore_api_internal)
 
-        mock_insecure_channel.assert_called_once_with(emulator_host)
+        mock_emulator_channel.assert_called_once()
 
         # Call again to show that it is cached, but call count is still 1.
         self.assertIs(client._firestore_api, mock_client.return_value)


### PR DESCRIPTION
This changes the `grpc.Channel` used when connecting to a local emulator so that the client credentials are used. This allows for testing database rules against the emulator in python.

Fixes #https://github.com/googleapis/python-firestore/issues/268 

thanks
