### PR TITLE
fix: type hint

### DIFF
--- a/google/cloud/firestore_v1/client.py
+++ b/google/cloud/firestore_v1/client.py
@@ -44,7 +44,7 @@ from google.cloud.firestore_v1.services.firestore import client as firestore_cli
 from google.cloud.firestore_v1.services.firestore.transports import (
     grpc as firestore_grpc_transport,
 )
-from typing import Any, Generator, Iterable, Tuple
+from typing import Any, Generator, Iterable, Tuple, Union
 
 # Types needed only for Type Hints
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
@@ -117,7 +117,7 @@ class Client(BaseClient):
         """
         return self._target_helper(firestore_client.FirestoreClient)
 
-    def collection(self, *collection_path: Tuple[str]) -> CollectionReference:
+    def collection(self, *collection_path: Union[Tuple[str], str]) -> CollectionReference:
         """Get a reference to a collection.
 
         For a top-level collection:
@@ -137,7 +137,7 @@ class Client(BaseClient):
         Sub-collections can be nested deeper in a similar fashion.
 
         Args:
-            collection_path (Tuple[str, ...]): Can either be
+            collection_path (Union[Tuple[str, ...], str]): Can either be
 
                 * A single ``/``-delimited path to a collection
                 * A tuple of collection path segments
@@ -170,7 +170,7 @@ class Client(BaseClient):
         """
         return CollectionGroup(self._get_collection_reference(collection_id))
 
-    def document(self, *document_path: Tuple[str]) -> DocumentReference:
+    def document(self, *document_path: Union[Tuple[str], str]) -> DocumentReference:
         """Get a reference to a document in a collection.
 
         For a top-level document:
@@ -192,7 +192,7 @@ class Client(BaseClient):
         Documents in sub-collections can be nested deeper in a similar fashion.
 
         Args:
-            document_path (Tuple[str, ...]): Can either be
+            document_path (Union[Tuple[str, ...], str]): Can either be
 
                 * A single ``/``-delimited path to a document
                 * A tuple of document path segments


### PR DESCRIPTION
the `document` and `collection` functions can receive str or tuple of this
this goes up a false positive warning in the development

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
