### PR TITLE
fix: limit data transferred as part of list_documents as we don't require field data

### DIFF
--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -183,6 +183,10 @@ class BaseCollectionReference(object):
             "collection_id": self.id,
             "page_size": page_size,
             "show_missing": True,
+            # list_documents returns an iterator of document references, which do not
+            # include any fields. To save on data transfer, we can set a field_path mask
+            # to include no fields
+            "mask": {"field_paths": None}
         }
         kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -186,7 +186,7 @@ class BaseCollectionReference(object):
             # list_documents returns an iterator of document references, which do not
             # include any fields. To save on data transfer, we can set a field_path mask
             # to include no fields
-            "mask": {"field_paths": None}
+            "mask": {"field_paths": None},
         }
         kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
 

--- a/tests/unit/v1/test_async_collection.py
+++ b/tests/unit/v1/test_async_collection.py
@@ -252,6 +252,7 @@ class TestAsyncCollectionReference(aiounittest.AsyncTestCase):
                 "collection_id": collection.id,
                 "page_size": page_size,
                 "show_missing": True,
+                "mask": {"field_paths": None},
             },
             metadata=client._rpc_metadata,
             **kwargs,

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -245,6 +245,7 @@ class TestCollectionReference(unittest.TestCase):
                 "collection_id": collection.id,
                 "page_size": page_size,
                 "show_missing": True,
+                "mask": {"field_paths": None},
             },
             metadata=client._rpc_metadata,
             **kwargs,


### PR DESCRIPTION
As we don't use any of the field data as part of list_documents, we can exclude it from the request/wire :)

Fixes #5 🦕
