### PR TITLE
chore: use `gcp-sphinx-docfx-yaml`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -211,9 +211,7 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    # sphinx-docfx-yaml supports up to sphinx version 1.5.5.
-    # https://github.com/docascode/sphinx-docfx-yaml/issues/97
-    session.install("sphinx==1.5.5", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+    session.install("sphinx", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(


### PR DESCRIPTION
makes use of the updated plugin for generating DocFX YAMLs