### PR TITLE
chore: s.remove_staging_dirs() should only be called once

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -57,8 +57,6 @@ for library in s.get_staging_dirs(default_version):
         update_fixup_scripts(library)
         s.move(library / "scripts")
 
-s.remove_staging_dirs()
-
 for library in s.get_staging_dirs(admin_default_version):
     if library.parent.absolute() == 'admin':
         s.move(
@@ -69,8 +67,6 @@ for library in s.get_staging_dirs(admin_default_version):
         s.move(library / f"tests", f"tests")
         update_fixup_scripts(library)
         s.move(library / "scripts")
-
-s.remove_staging_dirs()
 
 for library in s.get_staging_dirs(bundle_default_version):
     if library.parent.absolute() == 'bundle':


### PR DESCRIPTION
There is [an issue](https://github.com/googleapis/python-firestore/blob/master/owlbot.py#L60) in the `owlbot.py` file added in #352 in that [s.remove_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L309) should only be called once after all the files are copied over.  [get_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L280) will only return staging directories that exist.