### PR TITLE
fix: reseed for each auto id on 3.6 to avoid collisions

### DIFF
--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -15,7 +15,6 @@
 """Classes for representing collections for the Google Cloud Firestore API."""
 import random
 import sys
-import uuid
 
 from google.api_core import retry as retries  # type: ignore
 
@@ -459,10 +458,9 @@ def _auto_id() -> str:
     """
     if sys.version_info < (3, 7):
         # TODO: remove when 3.6 support is discontinued.
-        # On python 3.6, random will provide the same results when forked. Reseed using a
-        # uuid4 on each iteration to avoid collisions.
-        seed = str(uuid.uuid4())
-        random.seed(seed)
+        # On python 3.6, random will provide the same results when forked. Reseed 
+        # on each iteration to avoid collisions.
+        random.seed()
 
     return "".join(random.choice(_AUTO_ID_CHARS) for _ in range(20))
 

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -458,7 +458,7 @@ def _auto_id() -> str:
     """
     if sys.version_info < (3, 7):
         # TODO: remove when 3.6 support is discontinued.
-        # On python 3.6, random will provide the same results when forked. Reseed 
+        # On python 3.6, random will provide the same results when forked. Reseed
         # on each iteration to avoid collisions.
         random.seed()
 

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -14,6 +14,7 @@
 
 """Classes for representing collections for the Google Cloud Firestore API."""
 import random
+import sys
 import uuid
 
 from google.api_core import retry as retries  # type: ignore
@@ -456,10 +457,13 @@ def _auto_id() -> str:
         str: A 20 character string composed of digits, uppercase and
         lowercase and letters.
     """
-    # If this client is forked, random will be seeded the same and it is possible to have
-    # collisions across forked processes. Avoid by seeding with a uuid.uuid4()
-    seed = uuid.uuid4()
-    random.seed(seed)
+    if sys.version_info < (3, 7):
+        # TODO: remove when 3.6 support is discontinued.
+        # On python 3.6, random will provide the same results when forked. Reseed using a
+        # uuid4 on each iteration to avoid collisions.
+        seed = str(uuid.uuid4())
+        random.seed(seed)
+
     return "".join(random.choice(_AUTO_ID_CHARS) for _ in range(20))
 
 

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -14,6 +14,7 @@
 
 """Classes for representing collections for the Google Cloud Firestore API."""
 import random
+import uuid
 
 from google.api_core import retry as retries  # type: ignore
 
@@ -157,7 +158,7 @@ class BaseCollectionReference(object):
     ) -> Tuple[DocumentReference, dict]:
         """Shared setup for async / sync :method:`add`"""
         if document_id is None:
-            document_id = _auto_id()
+             document_id = _auto_id()
 
         document_ref = self.document(document_id)
         kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
@@ -455,6 +456,10 @@ def _auto_id() -> str:
         str: A 20 character string composed of digits, uppercase and
         lowercase and letters.
     """
+    # Randome is not thread safe, reseed with a new
+    # uuid.uuid4() each iteration to avoid collisions.
+    seed = uuid.uuid4()
+    random.seed(seed)
     return "".join(random.choice(_AUTO_ID_CHARS) for _ in range(20))
 
 

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -456,8 +456,8 @@ def _auto_id() -> str:
         str: A 20 character string composed of digits, uppercase and
         lowercase and letters.
     """
-    # Random is not thread safe, reseed with a new
-    # uuid.uuid4() each iteration to avoid collisions.
+    # If this client is forked, random will be seeded the same and it is possible to have
+    # collisions across forked processes. Avoid by seeding with a uuid.uuid4()
     seed = uuid.uuid4()
     random.seed(seed)
     return "".join(random.choice(_AUTO_ID_CHARS) for _ in range(20))

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -158,7 +158,7 @@ class BaseCollectionReference(object):
     ) -> Tuple[DocumentReference, dict]:
         """Shared setup for async / sync :method:`add`"""
         if document_id is None:
-             document_id = _auto_id()
+            document_id = _auto_id()
 
         document_ref = self.document(document_id)
         kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
@@ -456,7 +456,7 @@ def _auto_id() -> str:
         str: A 20 character string composed of digits, uppercase and
         lowercase and letters.
     """
-    # Randome is not thread safe, reseed with a new
+    # Random is not thread safe, reseed with a new
     # uuid.uuid4() each iteration to avoid collisions.
     seed = uuid.uuid4()
     random.seed(seed)


### PR DESCRIPTION
Fixes #346 🦕

Upon further investigation, this is only an issue for python 3.6. In 2022, when 3.6 is no longer supported, this patch could be removed.