### PR TITLE
fix: expect 'DocumentSnapshot.__hash__' to expect 'DatetimeWithNanosecons'

### DIFF
--- a/google/cloud/firestore_v1/base_document.py
+++ b/google/cloud/firestore_v1/base_document.py
@@ -368,8 +368,8 @@ class DocumentSnapshot(object):
         return self._reference == other._reference and self._data == other._data
 
     def __hash__(self):
-        seconds = int(self.update_time.timestamp())
-        nanos = self.update_time.nanosecond
+        seconds = int(self.update_time.seconds) 
+        nanos = self.update_time.nanos
         return hash(self._reference) + hash(seconds) + hash(nanos)
 
     @property


### PR DESCRIPTION
Fixes #391  🦕
