### PR TITLE
feat: added new batch class for BulkWriter

### DIFF
--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -21,7 +21,9 @@ from google.cloud.firestore_v1.base_batch import BaseWriteBatch
 
 
 class WriteBatch(BaseWriteBatch):
-    """Accumulate write operations to be sent in a batch.
+    """Accumulate write operations to be sent in a batch. Use this over
+    `BulkWriteBatch` for lower volumes or when the order of operations
+    within a given batch is important.
 
     This has the same set of methods for write operations that
     :class:`~google.cloud.firestore_v1.document.DocumentReference` does,

--- a/google/cloud/firestore_v1/bulk_batch.py
+++ b/google/cloud/firestore_v1/bulk_batch.py
@@ -26,7 +26,7 @@ class BulkWriteBatch(BaseBatch):
     `WriteBatch` for higher volumes (e.g., via `BulkWriter`) and when the order
     of operations within a given batch is unimportant.
 
-    Because the order in which individual write operations land in the database
+    Because the order in which individual write operations are applied to the database
     is not guaranteed, `batch_write` RPCs can never contain multiple operations
     to the same document. If calling code detects a second write operation to a
     known document reference, it should first cut off the previous batch and

--- a/google/cloud/firestore_v1/bulk_batch.py
+++ b/google/cloud/firestore_v1/bulk_batch.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for batch requests to the Google Cloud Firestore API."""
+from google.api_core import gapic_v1  # type: ignore
+from google.api_core import retry as retries  # type: ignore
+
+from google.cloud.firestore_v1 import _helpers
+from google.cloud.firestore_v1.base_batch import BaseBatch
+from google.cloud.firestore_v1.types.firestore import BatchWriteResponse
+
+
+class BulkWriteBatch(BaseBatch):
+    """Accumulate write operations to be sent in a batch. Use this over
+    `WriteBatch` for higher volumes (e.g., via `BulkWriter`) and when the order
+    of operations within a given batch is unimportant.
+
+    Because the order in which individual write operations land in the database
+    is not guaranteed, `batch_write` RPCs can never contain multiple operations
+    to the same document. If calling code detects a second write operation to a
+    known document reference, it should first cut off the previous batch and
+    send it, then create a new batch starting with the latest write operation.
+    In practice, the [Async]BulkWriter classes handle this.
+
+    This has the same set of methods for write operations that
+    :class:`~google.cloud.firestore_v1.document.DocumentReference` does,
+    e.g. :meth:`~google.cloud.firestore_v1.document.DocumentReference.create`.
+
+    Args:
+        client (:class:`~google.cloud.firestore_v1.client.Client`):
+            The client that created this batch.
+    """
+
+    def __init__(self, client) -> None:
+        super(BulkWriteBatch, self).__init__(client=client)
+
+    def commit(
+        self, retry: retries.Retry = gapic_v1.method.DEFAULT, timeout: float = None
+    ) -> BatchWriteResponse:
+        """Writes the changes accumulated in this batch.
+
+        Write operations are not guaranteed to be applied in order and must not
+        contain multiple writes to any given document. Preferred over `commit`
+        for performance reasons if these conditions are acceptable.
+
+        Args:
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.  Defaults to a system-specified policy.
+            timeout (float): The timeout for this request.  Defaults to a
+                system-specified value.
+
+        Returns:
+            :class:`google.cloud.proto.firestore.v1.write.BatchWriteResponse`:
+            Container holding the write results corresponding to the changes
+            committed, returned in the same order as the changes were applied to
+            this batch. An individual write result contains an ``update_time``
+            field.
+        """
+        request, kwargs = self._prep_commit(retry, timeout)
+
+        _api = self._client._firestore_api
+        save_response: BatchWriteResponse = _api.batch_write(
+            request=request, metadata=self._client._rpc_metadata, **kwargs,
+        )
+
+        self._write_pbs = []
+        self.write_results = list(save_response.write_results)
+
+        return save_response
+
+    def _prep_commit(self, retry: retries.Retry, timeout: float):
+        request = {
+            "database": self._client._database_string,
+            "writes": self._write_pbs,
+            "labels": None,
+        }
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+        return request, kwargs

--- a/tests/unit/v1/test_base_batch.py
+++ b/tests/unit/v1/test_base_batch.py
@@ -13,16 +13,26 @@
 # limitations under the License.
 
 import unittest
+from google.cloud.firestore_v1.base_batch import BaseWriteBatch
 
 import mock
+
+
+class TestableBaseWriteBatch(BaseWriteBatch):
+    def __init__(self, client):
+        super().__init__(client=client)
+
+    """Create a fake subclass of `BaseWriteBatch` for the purposes of
+    evaluating the shared methods."""
+
+    def commit(self):
+        pass  # pragma: NO COVER
 
 
 class TestBaseWriteBatch(unittest.TestCase):
     @staticmethod
     def _get_target_class():
-        from google.cloud.firestore_v1.base_batch import BaseWriteBatch
-
-        return BaseWriteBatch
+        return TestableBaseWriteBatch
 
     def _make_one(self, *args, **kwargs):
         klass = self._get_target_class()

--- a/tests/unit/v1/test_batch.py
+++ b/tests/unit/v1/test_batch.py
@@ -18,6 +18,8 @@ import mock
 
 
 class TestWriteBatch(unittest.TestCase):
+    """Tests the WriteBatch.commit method"""
+
     @staticmethod
     def _get_target_class():
         from google.cloud.firestore_v1.batch import WriteBatch
@@ -61,6 +63,7 @@ class TestWriteBatch(unittest.TestCase):
         batch.create(document1, {"ten": 10, "buck": "ets"})
         document2 = client.document("c", "d", "e", "f")
         batch.delete(document2)
+        self.assertEqual(len(batch), 2)
         write_pbs = batch._write_pbs[::]
 
         write_results = batch.commit(**kwargs)

--- a/tests/unit/v1/test_bulk_batch.py
+++ b/tests/unit/v1/test_bulk_batch.py
@@ -1,0 +1,105 @@
+# Copyright 2021 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import mock
+
+
+class TestBulkWriteBatch(unittest.TestCase):
+    """Tests the BulkWriteBatch.commit method"""
+
+    @staticmethod
+    def _get_target_class():
+        from google.cloud.firestore_v1.bulk_batch import BulkWriteBatch
+
+        return BulkWriteBatch
+
+    def _make_one(self, *args, **kwargs):
+        klass = self._get_target_class()
+        return klass(*args, **kwargs)
+
+    def test_constructor(self):
+        batch = self._make_one(mock.sentinel.client)
+        self.assertIs(batch._client, mock.sentinel.client)
+        self.assertEqual(batch._write_pbs, [])
+        self.assertIsNone(batch.write_results)
+
+    def _write_helper(self, retry=None, timeout=None):
+        from google.cloud.firestore_v1 import _helpers
+        from google.cloud.firestore_v1.types import firestore
+        from google.cloud.firestore_v1.types import write
+
+        # Create a minimal fake GAPIC with a dummy result.
+        firestore_api = mock.Mock(spec=["batch_write"])
+        write_response = firestore.BatchWriteResponse(
+            write_results=[write.WriteResult(), write.WriteResult()],
+        )
+        firestore_api.batch_write.return_value = write_response
+        kwargs = _helpers.make_retry_timeout_kwargs(retry, timeout)
+
+        # Attach the fake GAPIC to a real client.
+        client = _make_client("grand")
+        client._firestore_api_internal = firestore_api
+
+        # Actually make a batch with some mutations and call commit().
+        batch = self._make_one(client)
+        document1 = client.document("a", "b")
+        self.assertFalse(document1 in batch)
+        batch.create(document1, {"ten": 10, "buck": "ets"})
+        self.assertTrue(document1 in batch)
+        document2 = client.document("c", "d", "e", "f")
+        batch.delete(document2)
+        write_pbs = batch._write_pbs[::]
+
+        resp = batch.commit(**kwargs)
+        self.assertEqual(resp.write_results, list(write_response.write_results))
+        self.assertEqual(batch.write_results, resp.write_results)
+        # Make sure batch has no more "changes".
+        self.assertEqual(batch._write_pbs, [])
+
+        # Verify the mocks.
+        firestore_api.batch_write.assert_called_once_with(
+            request={
+                "database": client._database_string,
+                "writes": write_pbs,
+                "labels": None,
+            },
+            metadata=client._rpc_metadata,
+            **kwargs,
+        )
+
+    def test_write(self):
+        self._write_helper()
+
+    def test_write_w_retry_timeout(self):
+        from google.api_core.retry import Retry
+
+        retry = Retry(predicate=object())
+        timeout = 123.0
+
+        self._write_helper(retry=retry, timeout=timeout)
+
+
+def _make_credentials():
+    import google.auth.credentials
+
+    return mock.Mock(spec=google.auth.credentials.Credentials)
+
+
+def _make_client(project="seventy-nine"):
+    from google.cloud.firestore_v1.client import Client
+
+    credentials = _make_credentials()
+    return Client(project=project, credentials=credentials)


### PR DESCRIPTION
As a component of the BulkWriter feature, this PR:

* Adds a new `BulkWriteBatch` class whose `commit` method uses the BatchWriteRequest proto.
* Adds `__len__` and `__contains__` magic methods to all Batch classes for interrogation of which write operations they contain at any given moment
* Adds the `abc.ABCMeta` metaclass to enforce that all batches implement `commit`
