### PR TITLE
fix: move to using insecure grpc channels with emulator

### DIFF
--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -170,7 +170,7 @@ class BaseClient(ClientWithProject):
         Creates an insecure channel to communicate with the local emulator.
         If credentials are provided the token is extracted and added to the
         headers. this supports local testing of firestore rules if the credentials
-        have been created from a signed custom token. 
+        have been created from a signed custom token.
 
         :return: grpc.Channel or grpc.aio.Channel
         """

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -177,15 +177,20 @@ class BaseClient(ClientWithProject):
         # TODO: Implement a special credentials type for emulator and use
         # "transport.create_channel" to create gRPC channels once google-auth
         # extends it's allowed credentials types.
+        # if "GrpcAsyncIOTransport" in str(transport.__name__):
+        #     return grpc.aio.secure_channel(
+        #         self._emulator_host, self._local_composite_credentials()
+        #     )
+        # else:
+        #     return grpc.secure_channel(
+        #         self._emulator_host, self._local_composite_credentials()
+        #     )
         if "GrpcAsyncIOTransport" in str(transport.__name__):
-            return grpc.aio.secure_channel(
-                self._emulator_host, self._local_composite_credentials()
-            )
+            return grpc.aio.insecure_channel(
+                self._emulator_host)
         else:
-            return grpc.secure_channel(
-                self._emulator_host, self._local_composite_credentials()
-            )
-
+            return grpc.insecure_channel(
+                self._emulator_host)
     def _local_composite_credentials(self):
         """
         Creates the credentials for the local emulator channel

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -175,7 +175,8 @@ class BaseClient(ClientWithProject):
         :return: grpc.Channel or grpc.aio.Channel
         """
         # Insecure channels are used for the emulator as secure channels
-        # cannot be used to communicate on some environments. https://github.com/googleapis/python-firestore/issues/359
+        # cannot be used to communicate on some environments.
+        # https://github.com/googleapis/python-firestore/issues/359
         options = []
         if self._credentials is not None and self._credentials.id_token is not None:
             options.append(("Authorization", f"Bearer {self._credentials.id_token}"))

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -177,9 +177,10 @@ class BaseClient(ClientWithProject):
         # Insecure channels are used for the emulator as secure channels
         # cannot be used to communicate on some environments.
         # https://github.com/googleapis/python-firestore/issues/359
-        options = []
+        token = "owner"
         if self._credentials is not None and self._credentials.id_token is not None:
-            options.append(("Authorization", f"Bearer {self._credentials.id_token}"))
+            token = self._credentials.id_token
+        options = [("Authorization", f"Bearer {token}")]
 
         if "GrpcAsyncIOTransport" in str(transport.__name__):
             return grpc.aio.insecure_channel(self._emulator_host, options=options)

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -177,20 +177,11 @@ class BaseClient(ClientWithProject):
         # TODO: Implement a special credentials type for emulator and use
         # "transport.create_channel" to create gRPC channels once google-auth
         # extends it's allowed credentials types.
-        # if "GrpcAsyncIOTransport" in str(transport.__name__):
-        #     return grpc.aio.secure_channel(
-        #         self._emulator_host, self._local_composite_credentials()
-        #     )
-        # else:
-        #     return grpc.secure_channel(
-        #         self._emulator_host, self._local_composite_credentials()
-        #     )
         if "GrpcAsyncIOTransport" in str(transport.__name__):
-            return grpc.aio.insecure_channel(
-                self._emulator_host)
+            return grpc.aio.insecure_channel(self._emulator_host)
         else:
-            return grpc.insecure_channel(
-                self._emulator_host)
+            return grpc.insecure_channel(self._emulator_host)
+
     def _local_composite_credentials(self):
         """
         Creates the credentials for the local emulator channel

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -187,32 +187,6 @@ class BaseClient(ClientWithProject):
         else:
             return grpc.insecure_channel(self._emulator_host, options=options)
 
-    def _local_composite_credentials(self):
-        """
-        Creates the credentials for the local emulator channel
-        :return: grpc.ChannelCredentials
-        """
-        credentials = google.auth.credentials.with_scopes_if_required(
-            self._credentials, None
-        )
-        request = google.auth.transport.requests.Request()
-
-        # Create the metadata plugin for inserting the authorization header.
-        metadata_plugin = google.auth.transport.grpc.AuthMetadataPlugin(
-            credentials, request
-        )
-
-        # Create a set of grpc.CallCredentials using the metadata plugin.
-        google_auth_credentials = grpc.metadata_call_credentials(metadata_plugin)
-
-        # Using the local_credentials to allow connection to emulator
-        local_credentials = grpc.local_channel_credentials()
-
-        # Combine the local credentials and the authorization credentials.
-        return grpc.composite_channel_credentials(
-            local_credentials, google_auth_credentials
-        )
-
     def _target_helper(self, client_class) -> str:
         """Return the target (where the API is).
         Eg. "firestore.googleapis.com"

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -169,7 +169,7 @@ class BaseClient(ClientWithProject):
         """
         Creates an insecure channel to communicate with the local emulator.
         If credentials are provided the token is extracted and added to the
-        headers. this supports local testing of firestore rules if the credentials
+        headers. This supports local testing of firestore rules if the credentials
         have been created from a signed custom token.
 
         :return: grpc.Channel or grpc.aio.Channel
@@ -177,6 +177,7 @@ class BaseClient(ClientWithProject):
         # Insecure channels are used for the emulator as secure channels
         # cannot be used to communicate on some environments.
         # https://github.com/googleapis/python-firestore/issues/359
+        # Default the token to a non-empty string, in this case "owner".
         token = "owner"
         if self._credentials is not None and self._credentials.id_token is not None:
             token = self._credentials.id_token

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -181,7 +181,6 @@ class BaseClient(ClientWithProject):
         if self._credentials is not None and self._credentials.id_token is not None:
             options.append(("Authorization", f"Bearer {self._credentials.id_token}"))
 
-        channel = None
         if "GrpcAsyncIOTransport" in str(transport.__name__):
             return grpc.aio.insecure_channel(self._emulator_host, options=options)
         else:

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -146,11 +146,11 @@ class TestBaseClient(unittest.TestCase):
         )
 
         emulator_host = "localhost:8081"
+        credentials = _make_credentials()
+        database = "quanta"
         with mock.patch("os.getenv") as getenv:
             getenv.return_value = emulator_host
-
-            credentials = _make_credentials()
-            database = "quanta"
+            credentials.id_token = None
             client = self._make_one(
                 project=self.PROJECT, credentials=credentials, database=database
             )
@@ -166,13 +166,9 @@ class TestBaseClient(unittest.TestCase):
         # NOTE: On windows, emulation requires an insecure channel. If this is
         # altered to use a secure channel, start by verifying that it still
         # works as expected on windows.
-        emulator_host = "localhost:8081"
         with mock.patch("os.getenv") as getenv:
             getenv.return_value = emulator_host
-
-            credentials = _make_credentials()
             credentials.id_token = "test"
-            database = "quanta"
             client = self._make_one(
                 project=self.PROJECT, credentials=credentials, database=database
             )

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -160,21 +160,6 @@ class TestBaseClient(unittest.TestCase):
         self.assertTrue(isinstance(channel, grpc.Channel))
         channel = client._emulator_channel(FirestoreGrpcAsyncIOTransport)
         self.assertTrue(isinstance(channel, grpc.aio.Channel))
-        # checks that the credentials are composite ones using a local channel from grpc
-        composite_credentials = client._local_composite_credentials()
-        self.assertTrue(isinstance(composite_credentials, grpc.ChannelCredentials))
-        self.assertTrue(
-            isinstance(
-                composite_credentials._credentials._call_credentialses[0],
-                grpc._cython.cygrpc.MetadataPluginCallCredentials,
-            )
-        )
-        self.assertTrue(
-            isinstance(
-                composite_credentials._credentials._channel_credentials,
-                grpc._cython.cygrpc.LocalChannelCredentials,
-            )
-        )
 
         # Verify that when credentials are provided with an id token it is used
         # for channel construction

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -396,6 +396,7 @@ def _make_credentials():
 
     return mock.Mock(spec=google.oauth2.credentials.Credentials)
 
+
 def _make_batch_response(**kwargs):
     from google.cloud.firestore_v1.types import firestore
 

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -392,10 +392,9 @@ class Test__get_doc_mask(unittest.TestCase):
 
 
 def _make_credentials():
-    import google.auth.credentials
+    import google.oauth2.credentials
 
-    return mock.Mock(spec=google.auth.credentials.Credentials)
-
+    return mock.Mock(spec=google.oauth2.credentials.Credentials)
 
 def _make_batch_response(**kwargs):
     from google.cloud.firestore_v1.types import firestore


### PR DESCRIPTION
Related to #359

On windows, configuring a secure channel with credentials will not connect.

