### PR TITLE
feat: add support for recursive queries

### DIFF
--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -76,6 +76,7 @@ class EmptyParam:
     
     When seen, the pseudo-singleton `empty_param` value below serves as a sentinel
     to indicate that the parameter was ignored by calling code."""
+
     def __eq__(self, other):
         return isinstance(other, EmptyParam)
 

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -70,20 +70,6 @@ _GRPC_ERROR_MAPPING = {
 }
 
 
-class EmptyParam:
-    """Default value for optional parameters used to disambiguate between
-    calling code passing `None` versus ignoring the parameter entirely.
-    
-    When seen, the pseudo-singleton `empty_param` value below serves as a sentinel
-    to indicate that the parameter was ignored by calling code."""
-
-    def __eq__(self, other):
-        return isinstance(other, EmptyParam)
-
-
-empty_param = EmptyParam()
-
-
 class GeoPoint(object):
     """Simple container for a geo point value.
 

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -70,6 +70,19 @@ _GRPC_ERROR_MAPPING = {
 }
 
 
+class EmptyParam:
+    """Default value for optional parameters used to disambiguate between
+    calling code passing `None` versus ignoring the parameter entirely.
+    
+    When seen, the pseudo-singleton `empty_param` value below serves as a sentinel
+    to indicate that the parameter was ignored by calling code."""
+    def __eq__(self, other):
+        return isinstance(other, EmptyParam)
+
+
+empty_param = EmptyParam()
+
+
 class GeoPoint(object):
     """Simple container for a geo point value.
 

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -139,20 +139,17 @@ def verify_path(path, is_collection) -> None:
     """
     num_elements = len(path)
     if num_elements == 0:
-        raise ValueError(
-            f"Document or collection path cannot be empty. Encountered {path}"
-        )
+        raise ValueError("Document or collection path cannot be empty")
+
 
     if is_collection:
         if num_elements % 2 == 0:
-            raise ValueError(
-                f"A collection must have an odd number of path elements. Encountered {path}"
-            )
+            raise ValueError("A collection must have an odd number of path elements")
+
     else:
         if num_elements % 2 == 1:
-            raise ValueError(
-                f"A document must have an even number of path elements. Encountered {path}"
-            )
+            raise ValueError("A document must have an even number of path elements")
+
 
     for element in path:
         if not isinstance(element, str):

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -141,7 +141,6 @@ def verify_path(path, is_collection) -> None:
     if num_elements == 0:
         raise ValueError("Document or collection path cannot be empty")
 
-
     if is_collection:
         if num_elements % 2 == 0:
             raise ValueError("A collection must have an odd number of path elements")
@@ -149,7 +148,6 @@ def verify_path(path, is_collection) -> None:
     else:
         if num_elements % 2 == 1:
             raise ValueError("A document must have an even number of path elements")
-
 
     for element in path:
         if not isinstance(element, str):

--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -139,14 +139,20 @@ def verify_path(path, is_collection) -> None:
     """
     num_elements = len(path)
     if num_elements == 0:
-        raise ValueError("Document or collection path cannot be empty")
+        raise ValueError(
+            f"Document or collection path cannot be empty. Encountered {path}"
+        )
 
     if is_collection:
         if num_elements % 2 == 0:
-            raise ValueError("A collection must have an odd number of path elements")
+            raise ValueError(
+                f"A collection must have an odd number of path elements. Encountered {path}"
+            )
     else:
         if num_elements % 2 == 1:
-            raise ValueError("A document must have an even number of path elements")
+            raise ValueError(
+                f"A document must have an even number of path elements. Encountered {path}"
+            )
 
     for element in path:
         if not isinstance(element, str):

--- a/google/cloud/firestore_v1/async_query.py
+++ b/google/cloud/firestore_v1/async_query.py
@@ -22,6 +22,7 @@ a more common way to create a query than direct usage of the constructor.
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 
+from google.cloud import firestore_v1
 from google.cloud.firestore_v1.base_query import (
     BaseCollectionGroup,
     BaseQuery,
@@ -32,7 +33,7 @@ from google.cloud.firestore_v1.base_query import (
 )
 
 from google.cloud.firestore_v1 import async_document
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Type
 
 # Types needed only for Type Hints
 from google.cloud.firestore_v1.transaction import Transaction
@@ -92,6 +93,9 @@ class AsyncQuery(BaseQuery):
             When false, selects only collections that are immediate children
             of the `parent` specified in the containing `RunQueryRequest`.
             When true, selects all descendant collections.
+        recursive (Optional[bool]):
+            When true, returns all documents and all documents in any subcollections
+            below them. Defaults to false.
     """
 
     def __init__(
@@ -106,6 +110,7 @@ class AsyncQuery(BaseQuery):
         start_at=None,
         end_at=None,
         all_descendants=False,
+        recursive=False,
     ) -> None:
         super(AsyncQuery, self).__init__(
             parent=parent,
@@ -118,6 +123,7 @@ class AsyncQuery(BaseQuery):
             start_at=start_at,
             end_at=end_at,
             all_descendants=all_descendants,
+            recursive=recursive,
         )
 
     async def get(
@@ -224,6 +230,14 @@ class AsyncQuery(BaseQuery):
             if snapshot is not None:
                 yield snapshot
 
+    @staticmethod
+    def _get_collection_reference_class() -> Type[
+        "firestore_v1.async_collection.AsyncCollectionReference"
+    ]:
+        from google.cloud.firestore_v1.async_collection import AsyncCollectionReference
+
+        return AsyncCollectionReference
+
 
 class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
     """Represents a Collection Group in the Firestore API.
@@ -249,6 +263,7 @@ class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
         start_at=None,
         end_at=None,
         all_descendants=True,
+        recursive=False,
     ) -> None:
         super(AsyncCollectionGroup, self).__init__(
             parent=parent,
@@ -261,6 +276,7 @@ class AsyncCollectionGroup(AsyncQuery, BaseCollectionGroup):
             start_at=start_at,
             end_at=end_at,
             all_descendants=all_descendants,
+            recursive=recursive,
         )
 
     @staticmethod

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -124,7 +124,7 @@ class BaseCollectionReference(object):
         if document_id is None:
             document_id = _auto_id()
 
-        child_path = self._path + (document_id,)
+        child_path = self._path + (document_id,) if self._path[0] else (document_id,)
         return self._client.document(*child_path)
 
     def _parent_info(self) -> Tuple[Any, str]:
@@ -199,6 +199,9 @@ class BaseCollectionReference(object):
         Generator[DocumentReference, Any, Any], AsyncGenerator[DocumentReference, Any]
     ]:
         raise NotImplementedError
+
+    def recursive(self) -> "BaseQuery":
+        return self._query().recursive()
 
     def select(self, field_paths: Iterable[str]) -> BaseQuery:
         """Create a "select" query with this collection as parent.

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -124,7 +124,7 @@ class BaseCollectionReference(object):
         if document_id is None:
             document_id = _auto_id()
 
-        # Append `self._path` and the passed document's  Id as long as the first
+        # Append `self._path` and the passed document's ID as long as the first
         # element in the path is not an empty string, which comes from setting the
         # parent to "" for recursive queries.
         child_path = self._path + (document_id,) if self._path[0] else (document_id,)

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -124,7 +124,10 @@ class BaseCollectionReference(object):
         if document_id is None:
             document_id = _auto_id()
 
-        child_path = self._path + (document_id,)
+        # Append `self._path` and the passed document's  Id as long as the first
+        # element in the path is not an empty string, which comes from setting the
+        # parent to "" for recursive queries.
+        child_path = self._path + (document_id,) if self._path[0] else (document_id,)
         return self._client.document(*child_path)
 
     def _parent_info(self) -> Tuple[Any, str]:

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -124,7 +124,7 @@ class BaseCollectionReference(object):
         if document_id is None:
             document_id = _auto_id()
 
-        child_path = self._path + (document_id,) if self._path[0] else (document_id,)
+        child_path = self._path + (document_id,)
         return self._client.document(*child_path)
 
     def _parent_info(self) -> Tuple[Any, str]:

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -847,12 +847,12 @@ class BaseQuery(object):
             # add the following arcane filters.
 
             REFERENCE_NAME_MIN_ID = "__id-9223372036854775808__"
+            start_at = f'{original_collection_id}/{REFERENCE_NAME_MIN_ID}'
+            
+            # The backend interprets this null character is flipping the filter
+            # to mean the end of the range instead of the beginning.
             nullChar = "\0"
-            start_at = original_collection_id + "/" + REFERENCE_NAME_MIN_ID
-            end_at = original_collection_id + nullChar + "/" + REFERENCE_NAME_MIN_ID
-
-            # print(f'start_at: {type(start_at)} :: {start_at}')
-            # print(f'end_at: {type(end_at)} :: {end_at}')
+            end_at = f'{original_collection_id}{nullChar}/{REFERENCE_NAME_MIN_ID}'
 
             copied = (
                 copied.order_by(field_path_module.FieldPath.document_id())

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -33,7 +33,17 @@ from google.cloud.firestore_v1.types import query
 from google.cloud.firestore_v1.types import Cursor
 from google.cloud.firestore_v1.types import RunQueryResponse
 from google.cloud.firestore_v1.order import Order
-from typing import Any, Dict, Generator, Iterable, NoReturn, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    NoReturn,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 # Types needed only for Type Hints
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
@@ -144,6 +154,9 @@ class BaseQuery(object):
             When false, selects only collections that are immediate children
             of the `parent` specified in the containing `RunQueryRequest`.
             When true, selects all descendant collections.
+        recursive (Optional[bool]):
+            When true, returns all documents and all documents in any subcollections
+            below them. Defaults to false.
     """
 
     ASCENDING = "ASCENDING"
@@ -163,6 +176,7 @@ class BaseQuery(object):
         start_at=None,
         end_at=None,
         all_descendants=False,
+        recursive=False,
     ) -> None:
         self._parent = parent
         self._projection = projection
@@ -174,6 +188,7 @@ class BaseQuery(object):
         self._start_at = start_at
         self._end_at = end_at
         self._all_descendants = all_descendants
+        self._recursive = recursive
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -247,6 +262,7 @@ class BaseQuery(object):
         start_at: Optional[Tuple[dict, bool]] = _not_passed,
         end_at: Optional[Tuple[dict, bool]] = _not_passed,
         all_descendants: Optional[bool] = _not_passed,
+        recursive: Optional[bool] = _not_passed,
     ) -> "BaseQuery":
         return self.__class__(
             self._parent,
@@ -261,6 +277,7 @@ class BaseQuery(object):
             all_descendants=self._evaluate_param(
                 all_descendants, self._all_descendants
             ),
+            recursive=self._evaluate_param(recursive, self._recursive),
         )
 
     def _evaluate_param(self, value, fallback_value):
@@ -813,6 +830,38 @@ class BaseQuery(object):
     def on_snapshot(self, callback) -> NoReturn:
         raise NotImplementedError
 
+    def recursive(self) -> "BaseQuery":
+        copied = self._copy(recursive=True, all_descendants=True)
+        if copied._parent and copied._parent.id:
+            original_collection_id = "/".join(copied._parent._path)
+
+            # Reset the parent to nothing, so we can recurse through the
+            # entire database. This is required to have `CollectionSelector.collection_id`
+            # not override `CollectionSelector.all_descendants`, which happens
+            # if both are set.
+            copied._parent = copied._get_collection_reference_class()("")
+            copied._parent._client = self._parent._client
+
+            # But wait! We don't want to load the entire database; only the
+            # collection the user originally specified. To accomplish that, we
+            # add the following arcane filters.
+
+            REFERENCE_NAME_MIN_ID = "__id-9223372036854775808__"
+            nullChar = "\0"
+            start_at = original_collection_id + "/" + REFERENCE_NAME_MIN_ID
+            end_at = original_collection_id + nullChar + "/" + REFERENCE_NAME_MIN_ID
+
+            # print(f'start_at: {type(start_at)} :: {start_at}')
+            # print(f'end_at: {type(end_at)} :: {end_at}')
+
+            copied = (
+                copied.order_by(field_path_module.FieldPath.document_id())
+                .start_at({field_path_module.FieldPath.document_id(): start_at})
+                .end_at({field_path_module.FieldPath.document_id(): end_at})
+            )
+
+        return copied
+
     def _comparator(self, doc1, doc2) -> int:
         _orders = self._orders
 
@@ -1073,6 +1122,7 @@ class BaseCollectionGroup(BaseQuery):
         start_at=None,
         end_at=None,
         all_descendants=True,
+        recursive=False,
     ) -> None:
         if not all_descendants:
             raise ValueError("all_descendants must be True for collection group query.")
@@ -1088,6 +1138,7 @@ class BaseCollectionGroup(BaseQuery):
             start_at=start_at,
             end_at=end_at,
             all_descendants=all_descendants,
+            recursive=recursive,
         )
 
     def _validate_partition_query(self):
@@ -1131,6 +1182,10 @@ class BaseCollectionGroup(BaseQuery):
     def get_partitions(
         self, partition_count, retry: retries.Retry = None, timeout: float = None,
     ) -> NoReturn:
+        raise NotImplementedError
+
+    @staticmethod
+    def _get_collection_reference_class() -> Type["BaseCollectionGroup"]:
         raise NotImplementedError
 
 

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -847,12 +847,12 @@ class BaseQuery(object):
             # add the following arcane filters.
 
             REFERENCE_NAME_MIN_ID = "__id-9223372036854775808__"
-            start_at = f'{original_collection_id}/{REFERENCE_NAME_MIN_ID}'
-            
+            start_at = f"{original_collection_id}/{REFERENCE_NAME_MIN_ID}"
+
             # The backend interprets this null character is flipping the filter
             # to mean the end of the range instead of the beginning.
             nullChar = "\0"
-            end_at = f'{original_collection_id}{nullChar}/{REFERENCE_NAME_MIN_ID}'
+            end_at = f"{original_collection_id}{nullChar}/{REFERENCE_NAME_MIN_ID}"
 
             copied = (
                 copied.order_by(field_path_module.FieldPath.document_id())

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -831,14 +831,22 @@ class BaseQuery(object):
         raise NotImplementedError
 
     def recursive(self) -> "BaseQuery":
+        """Returns a copy of this query whose iterator will yield all matching
+        documents as well as each of their descendent subcollections and documents.
+
+        This differs from the `all_descendents` flag, which only returns descendents
+        whose subcollection names match the parent collection's name. To return
+        all descendents, regardless of their subcollection name, use this.
+        """
         copied = self._copy(recursive=True, all_descendants=True)
         if copied._parent and copied._parent.id:
             original_collection_id = "/".join(copied._parent._path)
 
-            # Reset the parent to nothing so we can recurse through the
-            # entire database. This is required to have `CollectionSelector.collection_id`
-            # not override `CollectionSelector.all_descendants`, which happens
-            # if both are set.
+            # Reset the parent to nothing so we can recurse through the entire
+            # database. This is required to have
+            # `CollectionSelector.collection_id` not override
+            # `CollectionSelector.all_descendants`, which happens if both are
+            # set.
             copied._parent = copied._get_collection_reference_class()("")
             copied._parent._client = self._parent._client
 

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -835,7 +835,7 @@ class BaseQuery(object):
         if copied._parent and copied._parent.id:
             original_collection_id = "/".join(copied._parent._path)
 
-            # Reset the parent to nothing, so we can recurse through the
+            # Reset the parent to nothing so we can recurse through the
             # entire database. This is required to have `CollectionSelector.collection_id`
             # not override `CollectionSelector.all_descendants`, which happens
             # if both are set.

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -19,6 +19,7 @@ a :class:`~google.cloud.firestore_v1.collection.Collection` and that can be
 a more common way to create a query than direct usage of the constructor.
 """
 
+from google.cloud import firestore_v1
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
@@ -34,7 +35,7 @@ from google.cloud.firestore_v1.base_query import (
 
 from google.cloud.firestore_v1 import document
 from google.cloud.firestore_v1.watch import Watch
-from typing import Any, Callable, Generator, List
+from typing import Any, Callable, Generator, List, Type
 
 
 class Query(BaseQuery):
@@ -105,6 +106,7 @@ class Query(BaseQuery):
         start_at=None,
         end_at=None,
         all_descendants=False,
+        recursive=False,
     ) -> None:
         super(Query, self).__init__(
             parent=parent,
@@ -117,6 +119,7 @@ class Query(BaseQuery):
             start_at=start_at,
             end_at=end_at,
             all_descendants=all_descendants,
+            recursive=recursive,
         )
 
     def get(
@@ -254,6 +257,14 @@ class Query(BaseQuery):
             self, callback, document.DocumentSnapshot, document.DocumentReference
         )
 
+    @staticmethod
+    def _get_collection_reference_class() -> Type[
+        "firestore_v1.collection.CollectionReference"
+    ]:
+        from google.cloud.firestore_v1.collection import CollectionReference
+
+        return CollectionReference
+
 
 class CollectionGroup(Query, BaseCollectionGroup):
     """Represents a Collection Group in the Firestore API.
@@ -279,6 +290,7 @@ class CollectionGroup(Query, BaseCollectionGroup):
         start_at=None,
         end_at=None,
         all_descendants=True,
+        recursive=False,
     ) -> None:
         super(CollectionGroup, self).__init__(
             parent=parent,
@@ -291,6 +303,7 @@ class CollectionGroup(Query, BaseCollectionGroup):
             start_at=start_at,
             end_at=end_at,
             all_descendants=all_descendants,
+            recursive=recursive,
         )
 
     @staticmethod

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1115,7 +1115,7 @@ async def test_recursive_query(client, cleanup):
 
     ids = [
         doc.id
-        async for doc in await db.collection_group("philosophers").recursive().get()
+        for doc in await db.collection_group("philosophers").recursive().get()
     ]
 
     expected_ids = [
@@ -1177,10 +1177,10 @@ async def test_nested_recursive_query(client, cleanup):
                 await inner_doc_ref.set(entry)
                 cleanup(inner_doc_ref.delete)
 
-    aristotle = await collection_ref.document(f"Aristotle{UNIQUE_RESOURCE_ID}-async")
+    aristotle = collection_ref.document(f"Aristotle{UNIQUE_RESOURCE_ID}-async")
     ids = [
         doc.id
-        async for doc in await aristotle.collection("pets")._query().recursive().get()
+        for doc in await aristotle.collection("pets")._query().recursive().get()
     ]
 
     expected_ids = [

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -48,7 +48,6 @@ def _get_credentials_and_project():
         credentials = EMULATOR_CREDS
         project = FIRESTORE_PROJECT
     else:
-        print(f"FIRESTORE_CREDS: {FIRESTORE_CREDS}")
         credentials = service_account.Credentials.from_service_account_file(
             FIRESTORE_CREDS
         )

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -48,6 +48,7 @@ def _get_credentials_and_project():
         credentials = EMULATOR_CREDS
         project = FIRESTORE_PROJECT
     else:
+        print(f"FIRESTORE_CREDS: {FIRESTORE_CREDS}")
         credentials = service_account.Credentials.from_service_account_file(
             FIRESTORE_CREDS
         )
@@ -1069,6 +1070,133 @@ async def test_batch(client, cleanup):
     assert snapshot2.update_time == write_result2.update_time
 
     assert not (await document3.get()).exists
+
+
+async def test_recursive_query(client, cleanup):
+
+    philosophers = [
+        {
+            "data": {"name": "Socrates", "favoriteCity": "Athens"},
+            "subcollections": {
+                "pets": [{"name": "Scruffy"}, {"name": "Snowflake"}],
+                "hobbies": [{"name": "pontificating"}, {"name": "journaling"}],
+                "philosophers": [{"name": "Aristotle"}, {"name": "Plato"}],
+            },
+        },
+        {
+            "data": {"name": "Aristotle", "favoriteCity": "Sparta"},
+            "subcollections": {
+                "pets": [{"name": "Floof-Boy"}, {"name": "Doggy-Dog"}],
+                "hobbies": [{"name": "questioning-stuff"}, {"name": "meditation"}],
+            },
+        },
+        {
+            "data": {"name": "Plato", "favoriteCity": "Corinth"},
+            "subcollections": {
+                "pets": [{"name": "Cuddles"}, {"name": "Sergeant-Puppers"}],
+                "hobbies": [{"name": "abstraction"}, {"name": "hypotheticals"}],
+            },
+        },
+    ]
+
+    db = client
+    collection_ref = db.collection("philosophers")
+    for philosopher in philosophers:
+        ref = collection_ref.document(
+            f"{philosopher['data']['name']}{UNIQUE_RESOURCE_ID}-async"
+        )
+        await ref.set(philosopher["data"])
+        cleanup(ref.delete)
+        for col_name, entries in philosopher["subcollections"].items():
+            sub_col = ref.collection(col_name)
+            for entry in entries:
+                inner_doc_ref = sub_col.document(entry["name"])
+                await inner_doc_ref.set(entry)
+                cleanup(inner_doc_ref.delete)
+
+    ids = [
+        doc.id
+        async for doc in await db.collection_group("philosophers").recursive().get()
+    ]
+
+    expected_ids = [
+        # Aristotle doc and subdocs
+        f"Aristotle{UNIQUE_RESOURCE_ID}-async",
+        "meditation",
+        "questioning-stuff",
+        "Doggy-Dog",
+        "Floof-Boy",
+        # Plato doc and subdocs
+        f"Plato{UNIQUE_RESOURCE_ID}-async",
+        "abstraction",
+        "hypotheticals",
+        "Cuddles",
+        "Sergeant-Puppers",
+        # Socrates doc and subdocs
+        f"Socrates{UNIQUE_RESOURCE_ID}-async",
+        "journaling",
+        "pontificating",
+        "Scruffy",
+        "Snowflake",
+        "Aristotle",
+        "Plato",
+    ]
+
+    assert len(ids) == len(expected_ids)
+
+    for index in range(len(ids)):
+        error_msg = (
+            f"Expected '{expected_ids[index]}' at spot {index}, " "got '{ids[index]}'"
+        )
+        assert ids[index] == expected_ids[index], error_msg
+
+
+async def test_nested_recursive_query(client, cleanup):
+
+    philosophers = [
+        {
+            "data": {"name": "Aristotle", "favoriteCity": "Sparta"},
+            "subcollections": {
+                "pets": [{"name": "Floof-Boy"}, {"name": "Doggy-Dog"}],
+                "hobbies": [{"name": "questioning-stuff"}, {"name": "meditation"}],
+            },
+        },
+    ]
+
+    db = client
+    collection_ref = db.collection("philosophers")
+    for philosopher in philosophers:
+        ref = collection_ref.document(
+            f"{philosopher['data']['name']}{UNIQUE_RESOURCE_ID}-async"
+        )
+        await ref.set(philosopher["data"])
+        cleanup(ref.delete)
+        for col_name, entries in philosopher["subcollections"].items():
+            sub_col = ref.collection(col_name)
+            for entry in entries:
+                inner_doc_ref = sub_col.document(entry["name"])
+                await inner_doc_ref.set(entry)
+                cleanup(inner_doc_ref.delete)
+
+    aristotle = await collection_ref.document(f"Aristotle{UNIQUE_RESOURCE_ID}-async")
+    ids = [
+        doc.id
+        async for doc in await aristotle.collection("pets")._query().recursive().get()
+    ]
+
+    expected_ids = [
+        # Aristotle pets
+        "Doggy-Dog",
+        "Floof-Boy",
+    ]
+
+    assert len(ids) == len(expected_ids)
+
+    for index in range(len(ids)):
+        error_msg = (
+            f"Expected '{expected_ids[index]}' at spot {index}, " "got '{ids[index]}'"
+        )
+        assert ids[index] == expected_ids[index], error_msg
 
 
 async def _chain(*iterators):

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1114,8 +1114,7 @@ async def test_recursive_query(client, cleanup):
                 cleanup(inner_doc_ref.delete)
 
     ids = [
-        doc.id
-        for doc in await db.collection_group("philosophers").recursive().get()
+        doc.id for doc in await db.collection_group("philosophers").recursive().get()
     ]
 
     expected_ids = [
@@ -1179,8 +1178,7 @@ async def test_nested_recursive_query(client, cleanup):
 
     aristotle = collection_ref.document(f"Aristotle{UNIQUE_RESOURCE_ID}-async")
     ids = [
-        doc.id
-        for doc in await aristotle.collection("pets")._query().recursive().get()
+        doc.id for doc in await aristotle.collection("pets")._query().recursive().get()
     ]
 
     expected_ids = [

--- a/tests/unit/v1/test_async_collection.py
+++ b/tests/unit/v1/test_async_collection.py
@@ -375,6 +375,12 @@ class TestAsyncCollectionReference(aiounittest.AsyncTestCase):
         query_instance = query_class.return_value
         query_instance.stream.assert_called_once_with(transaction=transaction)
 
+    def test_recursive(self):
+        from google.cloud.firestore_v1.async_query import AsyncQuery
+
+        col = self._make_one("collection")
+        self.assertIsInstance(col.recursive(), AsyncQuery)
+
 
 def _make_credentials():
     import google.auth.credentials

--- a/tests/unit/v1/test_async_collection.py
+++ b/tests/unit/v1/test_async_collection.py
@@ -51,6 +51,9 @@ class TestAsyncCollectionReference(aiounittest.AsyncTestCase):
         from google.cloud.firestore_v1.async_query import AsyncQuery
 
         query_methods = self._get_public_methods(AsyncQuery)
+        # Remove the one query-only method
+        query_methods.remove("copy")
+
         klass = self._get_target_class()
         collection_methods = self._get_public_methods(klass)
         # Make sure every query method is present on

--- a/tests/unit/v1/test_async_collection.py
+++ b/tests/unit/v1/test_async_collection.py
@@ -51,9 +51,6 @@ class TestAsyncCollectionReference(aiounittest.AsyncTestCase):
         from google.cloud.firestore_v1.async_query import AsyncQuery
 
         query_methods = self._get_public_methods(AsyncQuery)
-        # Remove the one query-only method
-        query_methods.remove("copy")
-
         klass = self._get_target_class()
         collection_methods = self._get_public_methods(klass)
         # Make sure every query method is present on

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -1151,6 +1151,12 @@ class TestBaseQuery(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Can only compare fields "):
             query._comparator(doc1, doc2)
 
+    def test_multiple_recursive_calls(self):
+        query = self._make_one(_make_client().collection("asdf"))
+        self.assertIsInstance(
+            query.recursive().recursive(), type(query),
+        )
+
 
 class Test__enum_from_op_string(unittest.TestCase):
     @staticmethod

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -349,3 +349,9 @@ class TestCollectionReference(unittest.TestCase):
         collection = self._make_one("collection")
         collection.on_snapshot(None)
         watch.for_query.assert_called_once()
+
+    def test_recursive(self):
+        from google.cloud.firestore_v1.query import Query
+
+        col = self._make_one("collection")
+        self.assertIsInstance(col.recursive(), Query)

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -51,6 +51,9 @@ class TestCollectionReference(unittest.TestCase):
         from google.cloud.firestore_v1.query import Query
 
         query_methods = self._get_public_methods(Query)
+        # Remove the one query-only method
+        query_methods.remove("copy")
+
         klass = self._get_target_class()
         collection_methods = self._get_public_methods(klass)
         # Make sure every query method is present on

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -51,9 +51,6 @@ class TestCollectionReference(unittest.TestCase):
         from google.cloud.firestore_v1.query import Query
 
         query_methods = self._get_public_methods(Query)
-        # Remove the one query-only method
-        query_methods.remove("copy")
-
         klass = self._get_target_class()
         collection_methods = self._get_public_methods(klass)
         # Make sure every query method is present on


### PR DESCRIPTION
Adds the ability for queries to begin fetching all nested documents _regardless of their collection name_. Previously, the only similar mechanic available was the `all_descendants` parameter (available via the `collection_group` class), which is imperfectly named and in fact only fetches all descendants _with the same `parent` name_. So, for example:

```
/users/alfred
/users/alfred/pets/scruffy
/users/alfred/users/alfreds-butler
```

In this case, running `db.collection_group('users').get()` would fetch `/users/alfred` and `/users/alfred/users/alfreds-butler`, but NOT `/users/alfred/pets/scruffy`.

Not that this is decidedly _not_ all of Alfred's descendants.

---

And thus: Recursive Queries ™️. Starting now, to fetch all three documents from the above hypothetical, a developer would run one of these two options:

```py
db.collection_group('users').recursive().get()
# or this similar statement with an identical outcome:
db.collections('users').recursive().get()
```