### PR TITLE
feat: add retry support for BulkWriter errors

### DIFF
--- a/google/cloud/firestore_v1/async_client.py
+++ b/google/cloud/firestore_v1/async_client.py
@@ -43,18 +43,13 @@ from google.cloud.firestore_v1.async_document import (
     DocumentSnapshot,
 )
 from google.cloud.firestore_v1.async_transaction import AsyncTransaction
-from google.cloud.firestore_v1.bulk_writer import (
-    BulkWriter,
-    BulkWriterOptions,
-    SendMode,
-)
 from google.cloud.firestore_v1.services.firestore import (
     async_client as firestore_client,
 )
 from google.cloud.firestore_v1.services.firestore.transports import (
     grpc_asyncio as firestore_grpc_transport,
 )
-from typing import Any, AsyncGenerator, Iterable, List, Optional
+from typing import Any, AsyncGenerator, Iterable, List
 
 
 class AsyncClient(BaseClient):
@@ -304,16 +299,6 @@ class AsyncClient(BaseClient):
 
         async for collection_id in iterator:
             yield self.collection(collection_id)
-
-    def bulk_writer(self, send_mode: Optional[SendMode] = None) -> BulkWriter:
-        """Get a BulkWriter instance from this client.
-
-        Returns:
-            :class:`@google.cloud.firestore_v1.bulk_writer.BulkWriter`:
-            A utility to efficiently create and save many `AsyncWriteBatch` instances
-            to the server.
-        """
-        return BulkWriter(client=self, options=BulkWriterOptions(mode=send_mode))
 
     def batch(self) -> AsyncWriteBatch:
         """Get a batch instance from this client.

--- a/google/cloud/firestore_v1/async_client.py
+++ b/google/cloud/firestore_v1/async_client.py
@@ -101,6 +101,19 @@ class AsyncClient(BaseClient):
             client_options=client_options,
         )
 
+    def _to_sync_copy(self):
+        from google.cloud.firestore_v1.client import Client
+
+        if not getattr(self, "_sync_copy", None):
+            self._sync_copy = Client(
+                project=self.project,
+                credentials=self._credentials,
+                database=self._database,
+                client_info=self._client_info,
+                client_options=self._client_options,
+            )
+        return self._sync_copy
+
     @property
     def _firestore_api(self):
         """Lazy-loading getter GAPIC Firestore API.

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -37,7 +37,10 @@ from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1 import __version__
 from google.cloud.firestore_v1 import types
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
-
+from google.cloud.firestore_v1.bulk_writer import (
+    BulkWriter,
+    BulkWriterOptions,
+)
 from google.cloud.firestore_v1.field_path import render_field_path
 from typing import (
     Any,
@@ -277,6 +280,21 @@ class BaseClient(ClientWithProject):
 
     def document(self, *document_path) -> BaseDocumentReference:
         raise NotImplementedError
+
+    def bulk_writer(self, options: Optional[BulkWriterOptions] = None) -> BulkWriter:
+        """Get a BulkWriter instance from this client.
+
+        Args:
+            :class:`@google.cloud.firestore_v1.bulk_writer.BulkWriterOptions`:
+            Optional control parameters for the
+            :class:`@google.cloud.firestore_v1.bulk_writer.BulkWriter` returned.
+
+        Returns:
+            :class:`@google.cloud.firestore_v1.bulk_writer.BulkWriter`:
+            A utility to efficiently create and save many `WriteBatch` instances
+            to the server.
+        """
+        return BulkWriter(client=self, options=options)
 
     def _document_path_helper(self, *document_path) -> List[str]:
         """Standardize the format of path to tuple of path segments and strip the database string from path if present.

--- a/google/cloud/firestore_v1/bulk_writer.py
+++ b/google/cloud/firestore_v1/bulk_writer.py
@@ -15,32 +15,59 @@
 """Helpers for efficiently writing large amounts of data to the Google Cloud
 Firestore API."""
 
+import bisect
 import collections
 import concurrent.futures
+import datetime
 import enum
 import functools
 import logging
 import time
-from typing import Callable, Dict, List, NoReturn, Optional, Union
+
+from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING
+
+from google.rpc import status_pb2  # type: ignore
 
 from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1.base_document import BaseDocumentReference
-from google.cloud.firestore_v1.base_client import BaseClient
 from google.cloud.firestore_v1.bulk_batch import BulkWriteBatch
 from google.cloud.firestore_v1.rate_limiter import RateLimiter
 from google.cloud.firestore_v1.types.firestore import BatchWriteResponse
 from google.cloud.firestore_v1.types.write import WriteResult
 
+if TYPE_CHECKING:
+    from google.cloud.firestore_v1.base_client import BaseClient  # pragma: NO COVER
+
 
 logger = logging.getLogger(__name__)
 
 
-class SendMode(enum.Enum):
-    """Control flag for whether a BulkWriter should commit batches in the main
-    thread or hand that work off to an executor.
-    """
+class BulkRetry(enum.Enum):
+    """Indicator for what retry strategy the BulkWriter should use."""
 
+    # Common exponential backoff algorithm. This strategy is largely incompatible
+    # with the default retry limit of 15, so use with caution.
+    exponential = enum.auto()
+
+    # Default strategy that adds 1 second of delay per retry.
+    linear = enum.auto()
+
+    # Immediate retries with no growing delays.
+    immediate = enum.auto()
+
+
+class SendMode(enum.Enum):
+    """Indicator for whether a BulkWriter should commit batches in the main
+    thread or hand that work off to an executor."""
+
+    # Default strategy that parallelizes network I/O on an executor. You almost
+    # certainly want this.
     parallel = enum.auto()
+
+    # Alternate strategy which blocks during all network I/O. Much slower, but
+    # assures all batches are sent to the server in order. Note that
+    # `SendMode.serial` is extremely susceptible to slowdowns from retries if
+    # there are a lot of errors.
     serial = enum.auto()
 
 
@@ -80,15 +107,22 @@ class AsyncBulkWriterMixin:
             if self._send_mode == SendMode.parallel:
                 return self._executor.submit(lambda: fn(self, *args, **kwargs))
             else:
-                return fn(self, *args, **kwargs)
+                # For code parity, even `SendMode.serial` scenarios should return
+                # a future here. Anything else would badly complicate calling code.
+                result = fn(self, *args, **kwargs)
+                future = concurrent.futures.Future()
+                future.set_result(result)
+                return future
 
         return wrapper
 
     @_with_send_mode
-    def _send_batch(self, batch: BulkWriteBatch):
+    def _send_batch(
+        self, batch: BulkWriteBatch, operations: List["BulkWriterOperation"]
+    ):
         """Sends a batch without regard to rate limits, meaning limits must have
         already been checked. To that end, do not call this directly; instead,
-        call `_send_next_batch_when_ready`.
+        call `_send_until_queue_is_empty`.
 
         Args:
             batch(:class:`~google.cloud.firestore_v1.base_batch.BulkWriteBatch`)
@@ -102,11 +136,14 @@ class AsyncBulkWriterMixin:
         self._total_batches_sent += 1
         self._total_write_operations += _len_batch
 
-        self._process_response(batch, response)
+        self._process_response(batch, response, operations)
 
     def _process_response(
-        self, batch: BulkWriteBatch, response: BatchWriteResponse
-    ) -> NoReturn:
+        self,
+        batch: BulkWriteBatch,
+        response: BatchWriteResponse,
+        operations: List["BulkWriterOperation"],
+    ) -> None:
         """Invokes submitted callbacks for each batch and each operation within
         each batch. As this is called from `_send_batch()`, this is parallelized
         if we are in that mode.
@@ -114,18 +151,52 @@ class AsyncBulkWriterMixin:
         batch_references: List[BaseDocumentReference] = list(
             batch._document_references.values(),
         )
-        if self._batch_callback:
-            self._batch_callback(batch, response, self)
-        if self._success_callback:
-            for index, result in enumerate(response.write_results):
-                if isinstance(result, WriteResult):
-                    # if `result.update_time` is None, this was probably a DELETE
-                    self._success_callback(batch_references[index], result, self)
-                else:
-                    # failure callback should go here
-                    # when we figure out what the error situation looks like,
-                    # the NO COVER should also be removed.
-                    pass  # pragma: NO COVER
+        self._batch_callback(batch, response, self)
+
+        status: status_pb2.Status
+        for index, status in enumerate(response.status):
+            if status.code == 0:
+                self._success_callback(
+                    # DocumentReference
+                    batch_references[index],
+                    # WriteResult
+                    response.write_results[index],
+                    # BulkWriter
+                    self,
+                )
+            else:
+                operation: BulkWriterOperation = operations[index]
+                should_retry: bool = self._error_callback(
+                    # BulkWriteFailure
+                    BulkWriteFailure(
+                        operation=operation, code=status.code, message=status.message,
+                    ),
+                    # BulkWriter
+                    self,
+                )
+                if should_retry:
+                    operation.attempts += 1
+                    self._retry_operation(operation)
+
+    def _retry_operation(
+        self, operation: "BulkWriterOperation",
+    ) -> concurrent.futures.Future:
+
+        delay: int = 0
+        if self._options.retry == BulkRetry.exponential:
+            delay = operation.attempts ** 2  # pragma: NO COVER
+        elif self._options.retry == BulkRetry.linear:
+            delay = operation.attempts
+
+        run_at = datetime.datetime.utcnow() + datetime.timedelta(seconds=delay)
+
+        # Use of `bisect.insort` maintains the requirement that `self._retries`
+        # always remain sorted by each object's `run_at` time. Note that it is
+        # able to do this because `OperationRetry` instances are entirely sortable
+        # by their `run_at` value.
+        bisect.insort(
+            self._retries, OperationRetry(operation=operation, run_at=run_at),
+        )
 
     def _send(self, batch: BulkWriteBatch) -> BatchWriteResponse:
         """Hook for overwriting the sending of batches. As this is only called
@@ -155,15 +226,15 @@ class BulkWriter(AsyncBulkWriterMixin):
         db = firestore.Client()
         bulk_writer = db.bulk_writer()
 
-        # Attach an optional success listener. This will be called once per
-        # document.
+        # Attach an optional success listener to be called once per document.
         bulk_writer.on_write_result(
-            lambda reference, result: print(f'Saved {reference._document_path}')
+            lambda reference, result, bulk_writer: print(f'Saved {reference._document_path}')
         )
 
         # Queue an arbitrary amount of write operations.
-        # `my_new_records` is a list of (DocumentReference, dict,) tuple-pairs
-        # that you supply.
+        # Assume `my_new_records` is a list of (DocumentReference, dict,)
+        # tuple-pairs that you supply.
+
         reference: DocumentReference
         data: dict
         for reference, data in my_new_records:
@@ -181,25 +252,52 @@ class BulkWriter(AsyncBulkWriterMixin):
 
     def __init__(
         self,
-        client: Optional[BaseClient] = None,
+        client: Optional["BaseClient"] = None,
         options: Optional["BulkWriterOptions"] = None,
     ):
-        self._client = client
+        # Because `BulkWriter` instances are all synchronous/blocking on the
+        # main thread (instead using other threads for asynchrony), it is
+        # incompatible with AsyncClient's various methods that return Futures.
+        # `BulkWriter` parallelizes all of its network I/O without the developer
+        # having to worry about awaiting async methods, so we must convert an
+        # AsyncClient instance into a plain Client instance.
+        self._client = (
+            client._to_sync_copy() if type(client).__name__ == "AsyncClient" else client
+        )
         self._options = options or BulkWriterOptions()
         self._send_mode = self._options.mode
-        # Redundantly set this variable for IDE type hints
-        self._batch: BulkWriteBatch = self._reset_batch()
+
+        self._operations: List[BulkWriterOperation]
+        # List of the `_document_path` attribute for each DocumentReference
+        # contained in the current `self._operations`. This is reset every time
+        # `self._operations` is reset.
+        self._operations_document_paths: List[BaseDocumentReference]
+        self._reset_operations()
+
+        # List of all `BulkWriterOperation` objects that are waiting to be retried.
+        # Each such object is wrapped in an `OperationRetry` object which pairs
+        # the raw operation with the `datetime` of its next scheduled attempt.
+        # `self._retries` must always remain sorted for efficient reads, so it is
+        # required to only ever add elements via `bisect.insort`.
+        self._retries: collections.deque["OperationRetry"] = collections.deque([])
+
         self._queued_batches = collections.deque([])
         self._is_open: bool = True
-        self._is_sending: bool = False
 
-        self._success_callback: Optional[
-            Callable[[BaseDocumentReference, WriteResult, "BulkWriter"], NoReturn]
-        ] = None
-        self._batch_callback: Optional[
-            Callable[[BulkWriteBatch, BatchWriteResponse, "BulkWriter"], NoReturn]
-        ] = None
-        self._error_callback: Optional[Callable] = None
+        # This list will go on to store the future returned from each submission
+        # to the executor, for the purpose of awaiting all of those futures'
+        # completions in the `flush` method.
+        self._pending_batch_futures: List[concurrent.futures.Future] = []
+
+        self._success_callback: Callable[
+            [BaseDocumentReference, WriteResult, "BulkWriter"], None
+        ] = BulkWriter._default_on_success
+        self._batch_callback: Callable[
+            [BulkWriteBatch, BatchWriteResponse, "BulkWriter"], None
+        ] = BulkWriter._default_on_batch
+        self._error_callback: Callable[
+            [BulkWriteFailure, BulkWriter], bool
+        ] = BulkWriter._default_on_error
 
         self._in_flight_documents: int = 0
         self._rate_limiter = RateLimiter(
@@ -213,19 +311,39 @@ class BulkWriter(AsyncBulkWriterMixin):
 
         self._ensure_executor()
 
-    def _reset_batch(self) -> BulkWriteBatch:
-        self._batch = BulkWriteBatch(self._client)
-        return self._batch
+    @staticmethod
+    def _default_on_batch(
+        batch: BulkWriteBatch, response: BatchWriteResponse, bulk_writer: "BulkWriter",
+    ) -> None:
+        pass
+
+    @staticmethod
+    def _default_on_success(
+        reference: BaseDocumentReference,
+        result: WriteResult,
+        bulk_writer: "BulkWriter",
+    ) -> None:
+        pass
+
+    @staticmethod
+    def _default_on_error(error: "BulkWriteFailure", bulk_writer: "BulkWriter") -> bool:
+        # Default number of retries for each operation is 15. This is a scary
+        # number to combine with an exponential backoff, and as such, our default
+        # backoff strategy is linear instead of exponential.
+        return error.attempts < 15
+
+    def _reset_operations(self) -> None:
+        self._operations = []
+        self._operations_document_paths = []
 
     def _ensure_executor(self):
-        self._executor = (
-            getattr(self, "_executor", None) or self._instantiate_executor()
-        )
+        """Reboots the executor used to send batches if it has been shutdown."""
+        if getattr(self, "_executor", None) is None or self._executor._shutdown:
+            self._executor = self._instantiate_executor()
 
     def _ensure_sending(self):
-        if not self._is_sending:
-            self._ensure_executor()
-            self._send_until_queue_is_empty()
+        self._ensure_executor()
+        self._send_until_queue_is_empty()
 
     def _instantiate_executor(self):
         return concurrent.futures.ThreadPoolExecutor()
@@ -236,30 +354,60 @@ class BulkWriter(AsyncBulkWriterMixin):
         accepting new write operations.
         """
         # Calling `flush` consecutively is a no-op.
-        if not self._executor:
+        if self._executor._shutdown:
             return
 
-        if len(self._batch) > 0:
-            self._enqueue_current_batch()
+        while True:
 
-        while self._queued_batches:
-            self._ensure_sending()
-            time.sleep(0.1)
+            # Queue any waiting operations and try our luck again.
+            # This can happen if users add a number of records not divisible by
+            # 20 and then call flush (which should be ~19 out of 20 use cases).
+            # Execution will arrive here and find the leftover operations that
+            # never filled up a batch organically, and so we must send them here.
+            if self._operations:
+                self._enqueue_current_batch()
+                continue
 
-        self._is_sending = False
+            # If we find queued but unsent batches or pending retries, begin
+            # sending immediately. Note that if we are waiting on retries, but
+            # they have longer to wait as specified by the retry backoff strategy,
+            # we may have to make several passes through this part of the loop.
+            # (This is related to the sleep and its explanation below.)
+            if self._queued_batches or self._retries:
+                self._ensure_sending()
+
+                # This sleep prevents max-speed laps through this loop, which can
+                # and will happen if the BulkWriter is doing nothing except waiting
+                # on retries to be ready to re-send. Removing this sleep will cause
+                # whatever thread is running this code to sit near 100% CPU until
+                # all retries are abandoned or successfully resolved.
+                time.sleep(0.1)
+                continue
+
+            # We store the executor's Future from each batch send operation, so
+            # the first pass through here, we are guaranteed to find "pending"
+            # batch futures and have to wait. However, the second pass through
+            # will be fast unless the last batch introduced more retries.
+            if self._pending_batch_futures:
+                _batches = self._pending_batch_futures
+                self._pending_batch_futures = []
+                concurrent.futures.wait(_batches)
+
+                # Continuing is critical here (as opposed to breaking) because
+                # the final batch may have introduced retries which is most
+                # straightforwardly verified by heading back to the top of the loop.
+                continue
+
+            break
+
+        # We no longer expect to have any queued batches or pending futures,
+        # so the executor can be shutdown.
         self._executor.shutdown()
-        # Completely release this resource, allowing our sending methods to
-        # easily detect if `flush` has been called and we should re-instantiate
-        # the executor. The reason for this is that `flush` hangs until everything
-        # is sent (and calling `shutdown` is the easiest way to do that), yet,
-        # it should not completely end the life of this BulkWriter. That role
-        # is filled by the `close` method.
-        self._executor = None
 
     def close(self):
         """
         Block until all pooled write operations are complete and then reject
-        any futher write operations.
+        any further write operations.
         """
         self._is_open = False
         self.flush()
@@ -268,28 +416,24 @@ class BulkWriter(AsyncBulkWriterMixin):
         """
         Checks to see whether the in-progress batch is full and, if it is,
         adds it to the sending queue.
-
-        Args:
-            force (bool): If true, sends the current batch even if it is only
-                partially full.
         """
-        if len(self._batch) >= self.batch_size:
+        if len(self._operations) >= self.batch_size:
             self._enqueue_current_batch()
 
     def _enqueue_current_batch(self):
         """Adds the current batch to the back of the sending line, resets the
-        local instance, and begins the process of actually sending whatever
+        list of queued ops, and begins the process of actually sending whatever
         batch is in the front of the line, which will often be a different batch.
         """
         # Put our batch in the back of the sending line
-        self._queued_batches.append(self._batch)
+        self._queued_batches.append(self._operations)
+
+        # Reset the local store of operations
+        self._reset_operations()
 
         # The sending loop powers off upon reaching the end of the queue, so
         # here we make sure that is running.
         self._ensure_sending()
-
-        # Reset the local instance
-        self._reset_batch()
 
     def _send_until_queue_is_empty(self):
         """First domino in the sending codepath. This does not need to be
@@ -306,39 +450,57 @@ class BulkWriter(AsyncBulkWriterMixin):
         Once `self._request_send()` returns, this method calls `self._send_batch()`,
         which parallelizes itself if that is our SendMode value.
 
-        And once `self._send_batch()` is called (which does not wait if we are
-        sending in parallel), this method calls itself; thus continuing to work
-        through all queued batches.
+        And once `self._send_batch()` is called (which does not block if we are
+        sending in parallel), jumps back to the top and re-checks for any queued
+        batches.
 
         Note that for sufficiently large data migrations, this can block the
         submission of additional write operations (e.g., the CRUD methods);
         but again, that is only if the maximum write speed is being exceeded,
         and thus this scenario does not actually further reduce performance.
         """
-        self._is_sending = True
-        # For FIFO order, add to the right of this deque (via `append`) and take
-        # from the left.
-        next_batch = self._queued_batches.popleft()
+        self._schedule_ready_retries()
 
-        # Block until we are cleared for takeoff, which is fine because this
-        # returns instantly unless the rate limiting logic determines that we
-        # are attempting to exceed the maximum write speed.
-        self._request_send(len(next_batch))
+        while self._queued_batches:
 
-        # Handle some bookkeeping, and ultimately put these bits on the wire.
-        # This call is optionally parallelized by `@_with_send_mode`.
-        self._send_batch(next_batch)
+            # For FIFO order, add to the right of this deque (via `append`) and take
+            # from the left (via `popleft`).
+            operations: List[BulkWriterOperation] = self._queued_batches.popleft()
 
-        if self._queued_batches:
-            # As long as there are more items to send, send the next one.
-            self._send_until_queue_is_empty()
-        else:
-            self._is_sending = False
+            # Block until we are cleared for takeoff, which is fine because this
+            # returns instantly unless the rate limiting logic determines that we
+            # are attempting to exceed the maximum write speed.
+            self._request_send(len(operations))
+
+            # Handle some bookkeeping, and ultimately put these bits on the wire.
+            batch = BulkWriteBatch(client=self._client)
+            op: BulkWriterOperation
+            for op in operations:
+                op.add_to_batch(batch)
+
+            # `_send_batch` is optionally parallelized by `@_with_send_mode`.
+            future = self._send_batch(batch=batch, operations=operations)
+            self._pending_batch_futures.append(future)
+
+            self._schedule_ready_retries()
+
+    def _schedule_ready_retries(self):
+        """Grabs all ready retries and re-queues them."""
+
+        # Because `self._retries` always exists in a sorted state (thanks to only
+        # ever adding to it via `bisect.insort`), and because `OperationRetry`
+        # objects are comparable against `datetime` objects, this bisect functionally
+        # returns the number of retires that are ready for immediate reenlistment.
+        take_until_index = bisect.bisect(self._retries, datetime.datetime.utcnow())
+
+        for _ in range(take_until_index):
+            retry: OperationRetry = self._retries.popleft()
+            retry.retry(self)
 
     def _request_send(self, batch_size: int) -> bool:
         # Set up this boolean to avoid repeatedly taking tokens if we're only
         # waiting on the `max_in_flight` limit.
-        can_send_batch: bool = False
+        have_received_tokens: bool = False
 
         while True:
             # To avoid bottlenecks on the server, an additional limit is that no
@@ -350,19 +512,23 @@ class BulkWriter(AsyncBulkWriterMixin):
             )
             # Ask for tokens each pass through this loop until they are granted,
             # and then stop.
-            can_send_batch = can_send_batch or self._rate_limiter.take_tokens(
-                batch_size
+            have_received_tokens = (
+                have_received_tokens or self._rate_limiter.take_tokens(batch_size)
             )
-            if not under_threshold or not can_send_batch:
+            if not under_threshold or not have_received_tokens:
                 # Try again until both checks are true.
+                # Note that this sleep is helpful to prevent the main BulkWriter
+                # thread from spinning through this loop as fast as possible and
+                # pointlessly burning CPU while we wait for the arrival of a
+                # fixed moment in the future.
                 time.sleep(0.01)
                 continue
 
             return True
 
     def create(
-        self, reference: BaseDocumentReference, document_data: Dict,
-    ) -> NoReturn:
+        self, reference: BaseDocumentReference, document_data: Dict, attempts: int = 0,
+    ) -> None:
         """Adds a `create` pb to the in-progress batch.
 
         If the in-progress batch already contains a write operation involving
@@ -382,17 +548,24 @@ class BulkWriter(AsyncBulkWriterMixin):
         """
         self._verify_not_closed()
 
-        if reference in self._batch:
+        if reference._document_path in self._operations_document_paths:
             self._enqueue_current_batch()
 
-        self._batch.create(reference, document_data)
+        self._operations.append(
+            BulkWriterCreateOperation(
+                reference=reference, document_data=document_data, attempts=attempts,
+            ),
+        )
+        self._operations_document_paths.append(reference._document_path)
+
         self._maybe_enqueue_current_batch()
 
     def delete(
         self,
         reference: BaseDocumentReference,
         option: Optional[_helpers.WriteOption] = None,
-    ) -> NoReturn:
+        attempts: int = 0,
+    ) -> None:
         """Adds a `delete` pb to the in-progress batch.
 
         If the in-progress batch already contains a write operation involving
@@ -412,10 +585,16 @@ class BulkWriter(AsyncBulkWriterMixin):
         """
         self._verify_not_closed()
 
-        if reference in self._batch:
+        if reference._document_path in self._operations_document_paths:
             self._enqueue_current_batch()
 
-        self._batch.delete(reference, option=option)
+        self._operations.append(
+            BulkWriterDeleteOperation(
+                reference=reference, option=option, attempts=attempts,
+            ),
+        )
+        self._operations_document_paths.append(reference._document_path)
+
         self._maybe_enqueue_current_batch()
 
     def set(
@@ -423,7 +602,8 @@ class BulkWriter(AsyncBulkWriterMixin):
         reference: BaseDocumentReference,
         document_data: Dict,
         merge: Union[bool, list] = False,
-    ) -> NoReturn:
+        attempts: int = 0,
+    ) -> None:
         """Adds a `set` pb to the in-progress batch.
 
         If the in-progress batch already contains a write operation involving
@@ -446,10 +626,19 @@ class BulkWriter(AsyncBulkWriterMixin):
         """
         self._verify_not_closed()
 
-        if reference in self._batch:
+        if reference._document_path in self._operations_document_paths:
             self._enqueue_current_batch()
 
-        self._batch.set(reference, document_data, merge=merge)
+        self._operations.append(
+            BulkWriterSetOperation(
+                reference=reference,
+                document_data=document_data,
+                merge=merge,
+                attempts=attempts,
+            )
+        )
+        self._operations_document_paths.append(reference._document_path)
+
         self._maybe_enqueue_current_batch()
 
     def update(
@@ -457,7 +646,8 @@ class BulkWriter(AsyncBulkWriterMixin):
         reference: BaseDocumentReference,
         field_updates: dict,
         option: Optional[_helpers.WriteOption] = None,
-    ) -> NoReturn:
+        attempts: int = 0,
+    ) -> None:
         """Adds an `update` pb to the in-progress batch.
 
         If the in-progress batch already contains a write operation involving
@@ -477,40 +667,148 @@ class BulkWriter(AsyncBulkWriterMixin):
             option (:class:`~google.cloud.firestore_v1._helpers.WriteOption`):
                 Optional flag to modify the nature of this write.
         """
+        # This check is copied from other Firestore classes for the purposes of
+        # surfacing the error immediately.
+        if option.__class__.__name__ == "ExistsOption":
+            raise ValueError("you must not pass an explicit write option to update.")
+
         self._verify_not_closed()
 
-        if reference in self._batch:
+        if reference._document_path in self._operations_document_paths:
             self._enqueue_current_batch()
 
-        self._batch.update(reference, field_updates, option=option)
+        self._operations.append(
+            BulkWriterUpdateOperation(
+                reference=reference,
+                field_updates=field_updates,
+                option=option,
+                attempts=attempts,
+            )
+        )
+        self._operations_document_paths.append(reference._document_path)
+
         self._maybe_enqueue_current_batch()
 
     def on_write_result(
         self,
-        callback: Callable[
-            [BaseDocumentReference, WriteResult, "BulkWriter"], NoReturn
-        ],
-    ) -> NoReturn:
+        callback: Callable[[BaseDocumentReference, WriteResult, "BulkWriter"], None],
+    ) -> None:
         """Sets a callback that will be invoked once for every successful operation."""
-        self._success_callback = callback
+        self._success_callback = callback or BulkWriter._default_on_success
 
     def on_batch_result(
         self,
-        callback: Callable[
-            [BulkWriteBatch, BatchWriteResponse, "BulkWriter"], NoReturn
-        ],
-    ) -> NoReturn:
+        callback: Callable[[BulkWriteBatch, BatchWriteResponse, "BulkWriter"], None],
+    ) -> None:
         """Sets a callback that will be invoked once for every successful batch."""
-        self._batch_callback = callback
+        self._batch_callback = callback or BulkWriter._default_on_batch
 
-    def on_write_error(self, callback: Callable) -> NoReturn:
+    def on_write_error(
+        self, callback: Callable[["BulkWriteFailure", "BulkWriter"], bool]
+    ) -> None:
         """Sets a callback that will be invoked once for every batch that contains
         an error."""
-        self._error_callback = callback  # pragma: NO COVER
+        self._error_callback = callback or BulkWriter._default_on_error
 
     def _verify_not_closed(self):
         if not self._is_open:
             raise Exception("BulkWriter is closed and cannot accept new operations")
+
+
+class BulkWriterOperation:
+    """Parent class for all operation container classes.
+
+    `BulkWriterOperation` exists to house all the necessary information for a
+    specific write task, including meta information like the current number of
+    attempts. If a write fails, it is its wrapper `BulkWriteOperation` class
+    that ferries it into its next retry without getting confused with other
+    similar writes to the same document.
+    """
+
+    def add_to_batch(self, batch: BulkWriteBatch):
+        """Adds `self` to the supplied batch."""
+        assert isinstance(batch, BulkWriteBatch)
+        if isinstance(self, BulkWriterCreateOperation):
+            return batch.create(
+                reference=self.reference, document_data=self.document_data,
+            )
+
+        if isinstance(self, BulkWriterDeleteOperation):
+            return batch.delete(reference=self.reference, option=self.option,)
+
+        if isinstance(self, BulkWriterSetOperation):
+            return batch.set(
+                reference=self.reference,
+                document_data=self.document_data,
+                merge=self.merge,
+            )
+
+        if isinstance(self, BulkWriterUpdateOperation):
+            return batch.update(
+                reference=self.reference,
+                field_updates=self.field_updates,
+                option=self.option,
+            )
+        raise TypeError(
+            f"Unexpected type of {self.__class__.__name__} for batch"
+        )  # pragma: NO COVER
+
+
+@functools.total_ordering
+class BaseOperationRetry:
+    """Parent class for both the @dataclass and old-style `OperationRetry`
+    classes.
+
+    Methods on this class be moved directly to `OperationRetry` when support for
+    Python 3.6 is dropped and `dataclasses` becomes universal.
+    """
+
+    def __lt__(self, other: "OperationRetry"):
+        """Allows use of `bisect` to maintain a sorted list of `OperationRetry`
+        instances, which in turn allows us to cheaply grab all that are ready to
+        run."""
+        if isinstance(other, OperationRetry):
+            return self.run_at < other.run_at
+        elif isinstance(other, datetime.datetime):
+            return self.run_at < other
+        return NotImplemented  # pragma: NO COVER
+
+    def retry(self, bulk_writer: BulkWriter) -> None:
+        """Call this after waiting any necessary time to re-add the enclosed
+        operation to the supplied BulkWriter's internal queue."""
+        if isinstance(self.operation, BulkWriterCreateOperation):
+            bulk_writer.create(
+                reference=self.operation.reference,
+                document_data=self.operation.document_data,
+                attempts=self.operation.attempts,
+            )
+
+        elif isinstance(self.operation, BulkWriterDeleteOperation):
+            bulk_writer.delete(
+                reference=self.operation.reference,
+                option=self.operation.option,
+                attempts=self.operation.attempts,
+            )
+
+        elif isinstance(self.operation, BulkWriterSetOperation):
+            bulk_writer.set(
+                reference=self.operation.reference,
+                document_data=self.operation.document_data,
+                merge=self.operation.merge,
+                attempts=self.operation.attempts,
+            )
+
+        elif isinstance(self.operation, BulkWriterUpdateOperation):
+            bulk_writer.update(
+                reference=self.operation.reference,
+                field_updates=self.operation.field_updates,
+                option=self.operation.option,
+                attempts=self.operation.attempts,
+            )
+        else:
+            raise TypeError(
+                f"Unexpected type of {self.operation.__class__.__name__} for OperationRetry.retry"
+            )  # pragma: NO COVER
 
 
 try:
@@ -521,9 +819,68 @@ try:
         initial_ops_per_second: int = 500
         max_ops_per_second: int = 500
         mode: SendMode = SendMode.parallel
+        retry: BulkRetry = BulkRetry.linear
+
+    @dataclass
+    class BulkWriteFailure:
+        operation: BulkWriterOperation
+        # https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+        code: int
+        message: str
+
+        @property
+        def attempts(self) -> int:
+            return self.operation.attempts
+
+    @dataclass
+    class OperationRetry(BaseOperationRetry):
+        """Container for an additional attempt at an operation, scheduled for
+        the future."""
+
+        operation: BulkWriterOperation
+        run_at: datetime.datetime
+
+    @dataclass
+    class BulkWriterCreateOperation(BulkWriterOperation):
+        """Container for BulkWriter.create() operations."""
+
+        reference: BaseDocumentReference
+        document_data: Dict
+        attempts: int = 0
+
+    @dataclass
+    class BulkWriterUpdateOperation(BulkWriterOperation):
+        """Container for BulkWriter.update() operations."""
+
+        reference: BaseDocumentReference
+        field_updates: Dict
+        option: Optional[_helpers.WriteOption]
+        attempts: int = 0
+
+    @dataclass
+    class BulkWriterSetOperation(BulkWriterOperation):
+        """Container for BulkWriter.set() operations."""
+
+        reference: BaseDocumentReference
+        document_data: Dict
+        merge: Union[bool, list] = False
+        attempts: int = 0
+
+    @dataclass
+    class BulkWriterDeleteOperation(BulkWriterOperation):
+        """Container for BulkWriter.delete() operations."""
+
+        reference: BaseDocumentReference
+        option: Optional[_helpers.WriteOption]
+        attempts: int = 0
 
 
 except ImportError:
+
+    # Note: When support for Python 3.6 is dropped and `dataclasses` is reliably
+    # in the stdlib, this entire section can be dropped in favor of the dataclass
+    # versions above. Additonally, the methods on `BaseOperationRetry` can be added
+    # directly to `OperationRetry` and `BaseOperationRetry` can be deleted.
 
     class BulkWriterOptions:
         def __init__(
@@ -531,7 +888,91 @@ except ImportError:
             initial_ops_per_second: int = 500,
             max_ops_per_second: int = 500,
             mode: SendMode = SendMode.parallel,
+            retry: BulkRetry = BulkRetry.linear,
         ):
             self.initial_ops_per_second = initial_ops_per_second
             self.max_ops_per_second = max_ops_per_second
             self.mode = mode
+            self.retry = retry
+
+    class BulkWriteFailure:
+        def __init__(
+            self,
+            operation: BulkWriterOperation,
+            # https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+            code: int,
+            message: str,
+        ):
+            self.operation = operation
+            self.code = code
+            self.message = message
+
+        @property
+        def attempts(self) -> int:
+            return self.operation.attempts
+
+    class OperationRetry(BaseOperationRetry):
+        """Container for an additional attempt at an operation, scheduled for
+        the future."""
+
+        def __init__(
+            self, operation: BulkWriterOperation, run_at: datetime.datetime,
+        ):
+            self.operation = operation
+            self.run_at = run_at
+
+    class BulkWriterCreateOperation(BulkWriterOperation):
+        """Container for BulkWriter.create() operations."""
+
+        def __init__(
+            self,
+            reference: BaseDocumentReference,
+            document_data: Dict,
+            attempts: int = 0,
+        ):
+            self.reference = reference
+            self.document_data = document_data
+            self.attempts = attempts
+
+    class BulkWriterUpdateOperation(BulkWriterOperation):
+        """Container for BulkWriter.update() operations."""
+
+        def __init__(
+            self,
+            reference: BaseDocumentReference,
+            field_updates: Dict,
+            option: Optional[_helpers.WriteOption],
+            attempts: int = 0,
+        ):
+            self.reference = reference
+            self.field_updates = field_updates
+            self.option = option
+            self.attempts = attempts
+
+    class BulkWriterSetOperation(BulkWriterOperation):
+        """Container for BulkWriter.set() operations."""
+
+        def __init__(
+            self,
+            reference: BaseDocumentReference,
+            document_data: Dict,
+            merge: Union[bool, list] = False,
+            attempts: int = 0,
+        ):
+            self.reference = reference
+            self.document_data = document_data
+            self.merge = merge
+            self.attempts = attempts
+
+    class BulkWriterDeleteOperation(BulkWriterOperation):
+        """Container for BulkWriter.delete() operations."""
+
+        def __init__(
+            self,
+            reference: BaseDocumentReference,
+            option: Optional[_helpers.WriteOption],
+            attempts: int = 0,
+        ):
+            self.reference = reference
+            self.option = option
+            self.attempts = attempts

--- a/google/cloud/firestore_v1/client.py
+++ b/google/cloud/firestore_v1/client.py
@@ -37,11 +37,6 @@ from google.cloud.firestore_v1.base_client import (
 
 from google.cloud.firestore_v1.query import CollectionGroup
 from google.cloud.firestore_v1.batch import WriteBatch
-from google.cloud.firestore_v1.bulk_writer import (
-    BulkWriter,
-    BulkWriterOptions,
-    SendMode,
-)
 from google.cloud.firestore_v1.collection import CollectionReference
 from google.cloud.firestore_v1.document import DocumentReference
 from google.cloud.firestore_v1.transaction import Transaction
@@ -49,7 +44,7 @@ from google.cloud.firestore_v1.services.firestore import client as firestore_cli
 from google.cloud.firestore_v1.services.firestore.transports import (
     grpc as firestore_grpc_transport,
 )
-from typing import Any, Generator, Iterable, Optional
+from typing import Any, Generator, Iterable
 
 # Types needed only for Type Hints
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
@@ -290,21 +285,6 @@ class Client(BaseClient):
 
         for collection_id in iterator:
             yield self.collection(collection_id)
-
-    def bulk_writer(self, send_mode: Optional[SendMode] = None) -> BulkWriter:
-        """Get a BulkWriter instance from this client.
-
-        Args:
-            :class:`@google.cloud.firestore_v1.bulk_writer.SendMode`:
-            Control flag for whether this BulkWriter instance should should
-            parallelize the sending of batches.
-
-        Returns:
-            :class:`@google.cloud.firestore_v1.bulk_writer.BulkWriter`:
-            A utility to efficiently create and save many `WriteBatch` instances
-            to the server.
-        """
-        return BulkWriter(client=self, options=BulkWriterOptions(mode=send_mode))
 
     def batch(self) -> WriteBatch:
         """Get a batch instance from this client.

--- a/tests/unit/v1/_test_helpers.py
+++ b/tests/unit/v1/_test_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import datetime
 import mock
 import typing
@@ -89,7 +90,16 @@ class FakeThreadPoolExecutor:
         self._shutdown = False
 
     def submit(self, callable) -> typing.NoReturn:
-        callable()
+        if self._shutdown:
+            raise RuntimeError(
+                "cannot schedule new futures after shutdown"
+            )  # pragma: NO COVER
+        future = concurrent.futures.Future()
+        future.set_result(callable())
+        return future
 
     def shutdown(self):
         self._shutdown = True
+
+    def __repr__(self):
+        return f"FakeThreadPoolExecutor(shutdown={self._shutdown})"

--- a/tests/unit/v1/test_async_client.py
+++ b/tests/unit/v1/test_async_client.py
@@ -381,7 +381,12 @@ class TestAsyncClient(aiounittest.AsyncTestCase):
         client = self._make_default_one()
         bulk_writer = client.bulk_writer()
         self.assertIsInstance(bulk_writer, BulkWriter)
-        self.assertIs(bulk_writer._client, client)
+        self.assertIs(bulk_writer._client, client._sync_copy)
+
+    def test_sync_copy(self):
+        client = self._make_default_one()
+        # Multiple calls to this method should return the same cached instance.
+        self.assertIs(client._to_sync_copy(), client._to_sync_copy())
 
     def test_batch(self):
         from google.cloud.firestore_v1.async_batch import AsyncWriteBatch

--- a/tests/unit/v1/test_bulk_writer.py
+++ b/tests/unit/v1/test_bulk_writer.py
@@ -14,20 +14,25 @@
 
 import datetime
 import unittest
-import aiounittest
-
 from typing import List, NoReturn, Optional, Tuple, Type
 
+from google.rpc import status_pb2
+import aiounittest  # type: ignore
 
-from google.cloud.firestore_v1._helpers import build_timestamp
+from google.cloud.firestore_v1._helpers import build_timestamp, ExistsOption
 from google.cloud.firestore_v1.async_client import AsyncClient
 from google.cloud.firestore_v1.base_document import BaseDocumentReference
 from google.cloud.firestore_v1.client import Client
 from google.cloud.firestore_v1.base_client import BaseClient
 from google.cloud.firestore_v1.bulk_batch import BulkWriteBatch
 from google.cloud.firestore_v1.bulk_writer import (
+    BulkRetry,
     BulkWriter,
+    BulkWriteFailure,
+    BulkWriterCreateOperation,
     BulkWriterOptions,
+    BulkWriterOperation,
+    OperationRetry,
     SendMode,
 )
 from google.cloud.firestore_v1.types.firestore import BatchWriteResponse
@@ -42,7 +47,9 @@ class NoSendBulkWriter(BulkWriter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._responses: List[Tuple[BulkWriteBatch, BatchWriteResponse]] = []
+        self._responses: List[
+            Tuple[BulkWriteBatch, BatchWriteResponse, BulkWriterOperation]
+        ] = []
         self._fail_indices: List[int] = []
 
     def _send(self, batch: BulkWriteBatch) -> BatchWriteResponse:
@@ -55,14 +62,21 @@ class NoSendBulkWriter(BulkWriter):
                 if index not in self._fail_indices
                 else WriteResult()
                 for index, el in enumerate(batch._document_references.values())
-            ]
+            ],
+            status=[
+                status_pb2.Status(code=0 if index not in self._fail_indices else 1)
+                for index, el in enumerate(batch._document_references.values())
+            ],
         )
 
     def _process_response(
-        self, batch: BulkWriteBatch, response: BatchWriteResponse
+        self,
+        batch: BulkWriteBatch,
+        response: BatchWriteResponse,
+        operations: List[BulkWriterOperation],
     ) -> NoReturn:
-        super()._process_response(batch, response)
-        self._responses.append((batch, response,))
+        super()._process_response(batch, response, operations)
+        self._responses.append((batch, response, operations))
 
     def _instantiate_executor(self):
         return FakeThreadPoolExecutor()
@@ -96,7 +110,7 @@ class _BaseBulkWriterTests:
     def _doc_iter(self, num: int, ids: Optional[List[str]] = None):
         for _ in range(num):
             id: Optional[str] = ids[_] if ids else None
-            yield self._get_document_reference(id=id), {"does.not": "matter"}
+            yield self._get_document_reference(id=id), {"id": _}
 
     def _verify_bw_activity(self, bw: BulkWriter, counts: List[Tuple[int, int]]):
         """
@@ -117,13 +131,16 @@ class _BaseBulkWriterTests:
         )
         docs_count = {}
         resp: BatchWriteResponse
-        for _, resp in bw._responses:
+        for _, resp, ops in bw._responses:
             docs_count.setdefault(len(resp.write_results), 0)
             docs_count[len(resp.write_results)] += 1
 
         self.assertEqual(len(docs_count), len(counts))
         for size, num_sent in counts:
             self.assertEqual(docs_count[size], num_sent)
+
+        # Assert flush leaves no operation behind
+        self.assertEqual(len(bw._operations), 0)
 
     def test_create_calls_send_correctly(self):
         bw = NoSendBulkWriter(self.client)
@@ -149,8 +166,7 @@ class _BaseBulkWriterTests:
         bw.create(ref, {})
         bw.delete(ref)
         bw.flush()
-        # Full batches with 20 items should have been sent 5 times, and a 1-item
-        # batch should have been sent once.
+        # Consecutive batches each with 1 operation should have been sent
         self._verify_bw_activity(bw, [(1, 2,)])
 
     def test_set_calls_send_correctly(self):
@@ -181,10 +197,9 @@ class _BaseBulkWriterTests:
         # batch should have been sent once.
         self._verify_bw_activity(bw, [(1, 2,)])
 
-    def test_invokes_callbacks_successfully(self):
+    def test_invokes_success_callbacks_successfully(self):
         bw = NoSendBulkWriter(self.client)
-        # First document in each batch will "fail"
-        bw._fail_indices = [0]
+        bw._fail_indices = []
         bw._sent_batches = 0
         bw._sent_documents = 0
 
@@ -198,19 +213,250 @@ class _BaseBulkWriterTests:
             assert isinstance(ref, BaseDocumentReference)
             assert isinstance(result, WriteResult)
             assert isinstance(bulk_writer, BulkWriter)
-            # Technically, a missing `update` time only means the operation did
-            # not involve an update, aka, was probably a `delete`. But this allows
-            # us to test that the data we expect was passed through to each callback.
-            if result.update_time is not None:
-                bulk_writer._sent_documents += 1
+            bulk_writer._sent_documents += 1
 
         bw.on_write_result(_on_write)
         bw.on_batch_result(_on_batch)
+
         for ref, data in self._doc_iter(101):
             bw.create(ref, data)
         bw.flush()
+
         self.assertEqual(bw._sent_batches, 6)
-        self.assertEqual(bw._sent_documents, 101 - 6)
+        self.assertEqual(bw._sent_documents, 101)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_invokes_error_callbacks_successfully(self):
+        bw = NoSendBulkWriter(self.client)
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._sent_batches = 0
+        bw._sent_documents = 0
+        bw._total_retries = 0
+
+        times_to_retry = 1
+
+        def _on_batch(batch, response, bulk_writer):
+            bulk_writer._sent_batches += 1
+
+        def _on_write(ref, result, bulk_writer):
+            bulk_writer._sent_documents += 1  # pragma: NO COVER
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_batch_result(_on_batch)
+        bw.on_write_result(_on_write)
+        bw.on_write_error(_on_error)
+
+        for ref, data in self._doc_iter(1):
+            bw.create(ref, data)
+        bw.flush()
+
+        self.assertEqual(bw._sent_documents, 0)
+        self.assertEqual(bw._total_retries, times_to_retry)
+        self.assertEqual(bw._sent_batches, 2)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_invokes_error_callbacks_successfully_multiple_retries(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._sent_batches = 0
+        bw._sent_documents = 0
+        bw._total_retries = 0
+
+        times_to_retry = 10
+
+        def _on_batch(batch, response, bulk_writer):
+            bulk_writer._sent_batches += 1
+
+        def _on_write(ref, result, bulk_writer):
+            bulk_writer._sent_documents += 1
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_batch_result(_on_batch)
+        bw.on_write_result(_on_write)
+        bw.on_write_error(_on_error)
+
+        for ref, data in self._doc_iter(2):
+            bw.create(ref, data)
+        bw.flush()
+
+        self.assertEqual(bw._sent_documents, 1)
+        self.assertEqual(bw._total_retries, times_to_retry)
+        self.assertEqual(bw._sent_batches, times_to_retry + 1)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_default_error_handler(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        bw._attempts = 0
+
+        def _on_error(error, bw):
+            bw._attempts = error.attempts
+            return bw._default_on_error(error, bw)
+
+        bw.on_write_error(_on_error)
+
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        for ref, data in self._doc_iter(1):
+            bw.create(ref, data)
+        bw.flush()
+        self.assertEqual(bw._attempts, 15)
+
+    def test_handles_errors_and_successes_correctly(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._sent_batches = 0
+        bw._sent_documents = 0
+        bw._total_retries = 0
+
+        times_to_retry = 1
+
+        def _on_batch(batch, response, bulk_writer):
+            bulk_writer._sent_batches += 1
+
+        def _on_write(ref, result, bulk_writer):
+            bulk_writer._sent_documents += 1
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_batch_result(_on_batch)
+        bw.on_write_result(_on_write)
+        bw.on_write_error(_on_error)
+
+        for ref, data in self._doc_iter(40):
+            bw.create(ref, data)
+        bw.flush()
+
+        # 19 successful writes per batch
+        self.assertEqual(bw._sent_documents, 38)
+        self.assertEqual(bw._total_retries, times_to_retry * 2)
+        self.assertEqual(bw._sent_batches, 4)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_create_retriable(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._total_retries = 0
+        times_to_retry = 6
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_write_error(_on_error)
+
+        for ref, data in self._doc_iter(1):
+            bw.create(ref, data)
+        bw.flush()
+
+        self.assertEqual(bw._total_retries, times_to_retry)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_delete_retriable(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._total_retries = 0
+        times_to_retry = 6
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_write_error(_on_error)
+
+        for ref, _ in self._doc_iter(1):
+            bw.delete(ref)
+        bw.flush()
+
+        self.assertEqual(bw._total_retries, times_to_retry)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_set_retriable(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._total_retries = 0
+        times_to_retry = 6
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_write_error(_on_error)
+
+        for ref, data in self._doc_iter(1):
+            bw.set(ref, data)
+        bw.flush()
+
+        self.assertEqual(bw._total_retries, times_to_retry)
+        self.assertEqual(len(bw._operations), 0)
+
+    def test_update_retriable(self):
+        bw = NoSendBulkWriter(
+            self.client, options=BulkWriterOptions(retry=BulkRetry.immediate),
+        )
+        # First document in each batch will "fail"
+        bw._fail_indices = [0]
+        bw._total_retries = 0
+        times_to_retry = 6
+
+        def _on_error(error, bw) -> bool:
+            assert isinstance(error, BulkWriteFailure)
+            should_retry = error.attempts < times_to_retry
+            if should_retry:
+                bw._total_retries += 1
+            return should_retry
+
+        bw.on_write_error(_on_error)
+
+        for ref, data in self._doc_iter(1):
+            bw.update(ref, data)
+        bw.flush()
+
+        self.assertEqual(bw._total_retries, times_to_retry)
+        self.assertEqual(len(bw._operations), 0)
 
     def test_serial_calls_send_correctly(self):
         bw = NoSendBulkWriter(
@@ -263,8 +509,8 @@ class _BaseBulkWriterTests:
         bw = NoSendBulkWriter(self.client)
         for _ in range(2):
             bw.create(self._get_document_reference(), {"whatever": "you want"})
-            bw._queued_batches.append(bw._batch)
-            bw._reset_batch()
+            bw._queued_batches.append(bw._operations)
+            bw._reset_operations()
         bw.flush()
         self._verify_bw_activity(bw, [(1, 2,)])
 
@@ -272,6 +518,21 @@ class _BaseBulkWriterTests:
         bw = NoSendBulkWriter(self.client)
         bw.close()
         self.assertRaises(Exception, bw._verify_not_closed)
+
+    def test_multiple_flushes(self):
+        bw = NoSendBulkWriter(self.client)
+        bw.flush()
+        bw.flush()
+
+    def test_update_raises_with_bad_option(self):
+        bw = NoSendBulkWriter(self.client)
+        self.assertRaises(
+            ValueError,
+            bw.update,
+            self._get_document_reference("id"),
+            {},
+            option=ExistsOption(exists=True),
+        )
 
 
 class TestSyncBulkWriter(_SyncClientMixin, _BaseBulkWriterTests, unittest.TestCase):
@@ -305,3 +566,35 @@ class TestScheduling(unittest.TestCase):
         self.assertGreater(
             datetime.datetime.now() - st, datetime.timedelta(milliseconds=90),
         )
+
+    def test_operation_retry_scheduling(self):
+        now = datetime.datetime.now()
+        one_second_from_now = now + datetime.timedelta(seconds=1)
+
+        db = Client()
+        operation = BulkWriterCreateOperation(
+            reference=db.collection("asdf").document("asdf"),
+            document_data={"does.not": "matter"},
+        )
+        operation2 = BulkWriterCreateOperation(
+            reference=db.collection("different").document("document"),
+            document_data={"different": "values"},
+        )
+
+        op1 = OperationRetry(operation=operation, run_at=now)
+        op2 = OperationRetry(operation=operation2, run_at=now)
+        op3 = OperationRetry(operation=operation, run_at=one_second_from_now)
+
+        self.assertLess(op1, op3)
+        self.assertLess(op1, op3.run_at)
+        self.assertLess(op2, op3)
+        self.assertLess(op2, op3.run_at)
+
+        # Because these have the same values for `run_at`, neither should conclude
+        # they are less than the other. It is okay that if we checked them with
+        # greater-than evaluation, they would return True (because
+        # @functools.total_ordering flips the result from __lt__). In practice,
+        # this only arises for actual ties, and we don't care how actual ties are
+        # ordered as we maintain the sorted list of scheduled retries.
+        self.assertFalse(op1 < op2)
+        self.assertFalse(op2 < op1)


### PR DESCRIPTION
Contains the extra retry logic for BulkWriter errors.

The high level changes of this PR vs the previous state of `bulk-writer-release` are:

1. A new wrapping class, `BulkWriteOperation`, is introduced. This wraps all the arguments for a given BulkWriter operation (`create`, `update`, `set`, or `delete`), along with meta information like how many attempts have been made so far.
2. The in-progress `BulkWriteBatch` is now replaced with a simple list of `BulkWriteOperation` instances.
3. Handling around `on_write`, `on_error`, and `on_batch` callbacks have been improved.
4. All futures from the executor are tracked, allowing `flush()` to wait on their completion. This is important because some of the final requests could fail, leading to last-second retries that `flush()` must also detect and wait on.