### PR TITLE
fix: remove unused requirement pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ dependencies = [
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-cloud-core >= 1.4.1, <3.0.0dev",
     "packaging >= 14.3",
-    "pytz",
     "proto-plus >= 1.10.0",
 ]
 extras = {}

--- a/tests/unit/v1/test_watch.py
+++ b/tests/unit/v1/test_watch.py
@@ -566,9 +566,7 @@ class TestWatch(unittest.TestCase):
         )
 
     def test_push_callback_called_no_changes(self):
-        import pytz
-
-        dummy_time = (datetime.datetime.fromtimestamp(1534858278, pytz.utc),)
+        dummy_time = (datetime.datetime.fromtimestamp(1534858278, datetime.timezone.utc),)
 
         inst = self._makeOne()
         inst.push(dummy_time, "token")

--- a/tests/unit/v1/test_watch.py
+++ b/tests/unit/v1/test_watch.py
@@ -566,7 +566,9 @@ class TestWatch(unittest.TestCase):
         )
 
     def test_push_callback_called_no_changes(self):
-        dummy_time = (datetime.datetime.fromtimestamp(1534858278, datetime.timezone.utc),)
+        dummy_time = (
+            datetime.datetime.fromtimestamp(1534858278, datetime.timezone.utc),
+        )
 
         inst = self._makeOne()
         inst.push(dummy_time, "token")


### PR DESCRIPTION
I noticed firestore doesn't seem to use pytz for anything other than a unit test.