### PR TITLE
fix: treat None cursors as a no-op.

### DIFF
--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -755,7 +755,7 @@ class BaseQuery(object):
 
             document_fields = values
 
-        if len(document_fields) > len(orders):
+        if document_fields and len(document_fields) > len(orders):
             msg = _MISMATCH_CURSOR_W_ORDER_BY.format(document_fields, order_keys)
             raise ValueError(msg)
 

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -726,6 +726,18 @@ class TestBaseQuery(unittest.TestCase):
         ]
         self.assertEqual(query._normalize_orders(), expected)
 
+    def test__normalize_orders_w_name_orders_w_none_cursor(self):
+        values = {"a": 7, "b": "foo"}
+        docref = self._make_docref("here", "doc_id")
+        collection = self._make_collection("here")
+        query = (
+            self._make_one(collection)
+            .order_by("__name__", "DESCENDING")
+            .start_at(None)
+        )
+        expected = [query._make_order("__name__", "DESCENDING")]
+        self.assertEqual(query._normalize_orders(), expected)
+
     def test__normalize_cursor_none(self):
         query = self._make_one(mock.sentinel.parent)
         self.assertIsNone(query._normalize_cursor(None, query._orders))

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -727,8 +727,6 @@ class TestBaseQuery(unittest.TestCase):
         self.assertEqual(query._normalize_orders(), expected)
 
     def test__normalize_orders_w_name_orders_w_none_cursor(self):
-        values = {"a": 7, "b": "foo"}
-        docref = self._make_docref("here", "doc_id")
         collection = self._make_collection("here")
         query = (
             self._make_one(collection).order_by("__name__", "DESCENDING").start_at(None)

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -731,9 +731,7 @@ class TestBaseQuery(unittest.TestCase):
         docref = self._make_docref("here", "doc_id")
         collection = self._make_collection("here")
         query = (
-            self._make_one(collection)
-            .order_by("__name__", "DESCENDING")
-            .start_at(None)
+            self._make_one(collection).order_by("__name__", "DESCENDING").start_at(None)
         )
         expected = [query._make_order("__name__", "DESCENDING")]
         self.assertEqual(query._normalize_orders(), expected)
@@ -1166,7 +1164,8 @@ class TestBaseQuery(unittest.TestCase):
     def test_multiple_recursive_calls(self):
         query = self._make_one(_make_client().collection("asdf"))
         self.assertIsInstance(
-            query.recursive().recursive(), type(query),
+            query.recursive().recursive(),
+            type(query),
         )
 
 

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -1164,8 +1164,7 @@ class TestBaseQuery(unittest.TestCase):
     def test_multiple_recursive_calls(self):
         query = self._make_one(_make_client().collection("asdf"))
         self.assertIsInstance(
-            query.recursive().recursive(),
-            type(query),
+            query.recursive().recursive(), type(query),
         )
 
 


### PR DESCRIPTION
fixes #439 