### PR TITLE
test: do not try to test with emulator if java not present

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -151,7 +151,7 @@ def system_emulated(session):
         ["gcloud", "components", "install", "beta", "cloud-firestore-emulator",]
     )
 
-    hostport = "0.0.0.0:8789"
+    hostport = "localhost:8789"
     session.env["FIRESTORE_EMULATOR_HOST"] = hostport
 
     p = subprocess.Popen(

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,6 +135,13 @@ def system_emulated(session):
     import signal
 
     try:
+        # https://github.com/googleapis/python-firestore/issues/472
+        # Kokoro image doesn't have java installed, don't attempt to run emulator.
+        subprocess.call(["java", "--version"])
+    except OSError:
+        session.skip("java not found but required for emulator support")
+
+    try:
         subprocess.call(["gcloud", "--version"])
     except OSError:
         session.skip("gcloud not found but required for emulator support")
@@ -144,7 +151,7 @@ def system_emulated(session):
         ["gcloud", "components", "install", "beta", "cloud-firestore-emulator",]
     )
 
-    hostport = "localhost:8789"
+    hostport = "0.0.0.0:8789"
     session.env["FIRESTORE_EMULATOR_HOST"] = hostport
 
     p = subprocess.Popen(

--- a/owlbot.py
+++ b/owlbot.py
@@ -162,6 +162,13 @@ def system_emulated(session):
     import signal
 
     try:
+        # https://github.com/googleapis/python-firestore/issues/472
+        # Kokoro image doesn't have java installed, don't attempt to run emulator.
+        subprocess.call(["java", "--version"])
+    except OSError:
+        session.skip("java not found but required for emulator support")
+
+    try:
         subprocess.call(["gcloud", "--version"])
     except OSError:
         session.skip("gcloud not found but required for emulator support")


### PR DESCRIPTION
This is related to #472 

Currently, Kokoro images do not have a java runtime available for python-multi. We could look to add a custom image, but for now, this will skip the emulator tests under our runs.