### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "firestore",
     "name_pretty": "Cloud Firestore",
     "product_documentation": "https://cloud.google.com/firestore",
-    "client_documentation": "https://googleapis.dev/python/firestore/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/firestore/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5337669",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ including Cloud Functions.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-firestore.svg
 .. _Google Cloud Firestore: https://cloud.google.com/firestore/
 .. _Product Documentation: https://cloud.google.com/firestore/docs/
-.. _Client Library Documentation: https://googleapis.dev/python/firestore/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/firestore/latest
 
 Quick Start
 -----------


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.