### PR TITLE
test: Make the tests pass in pytest-asyncio>=0.17

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -108,7 +108,7 @@ def default(session):
         "asyncmock",
         "pytest",
         "pytest-cov",
-        "pytest-asyncio<0.17.0",
+        "pytest-asyncio",
         "-c",
         constraints_path,
     )
@@ -214,7 +214,7 @@ def system(session):
         "mock",
         "pytest",
         "google-cloud-testutils",
-        "pytest-asyncio<0.17.0",
+        "pytest-asyncio",
         "-c",
         constraints_path,
     )


### PR DESCRIPTION
Unpin pytest-asyncio version.
Adjust the event_loop fixture to make it compatible with pytest-asyncio>=0.17
Use the @pytest_asyncio.fixture decorator for apropriately.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #524 🦕
