### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -171,7 +171,9 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx<3.0.0", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+    session.install(
+        "sphinx<3.0.0", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", BLACK_VERSION)
+    session.install("flake8", BLACK_VERSION, "click<8.1.0")
     session.run(
         "black", "--check", *BLACK_PATHS,
     )
@@ -58,7 +58,7 @@ def blacken(session):
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
-    session.install(BLACK_VERSION)
+    session.install(BLACK_VERSION, "click<8.1.0")
     session.run(
         "black", *BLACK_PATHS,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -164,4 +164,3 @@ def docs(session):
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
     )
-

--- a/noxfile.py
+++ b/noxfile.py
@@ -165,37 +165,3 @@ def docs(session):
         os.path.join("docs", "_build", "html", ""),
     )
 
-
-@nox.session(python=DEFAULT_PYTHON_VERSION)
-def docfx(session):
-    """Build the docfx yaml files for this library."""
-
-    session.install("-e", ".")
-    session.install(
-        "sphinx<3.0.0", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml"
-    )
-
-    shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
-    session.run(
-        "sphinx-build",
-        "-T",  # show full traceback on exception
-        "-N",  # no colors
-        "-D",
-        (
-            "extensions=sphinx.ext.autodoc,"
-            "sphinx.ext.autosummary,"
-            "docfx_yaml.extension,"
-            "sphinx.ext.intersphinx,"
-            "sphinx.ext.coverage,"
-            "sphinx.ext.napoleon,"
-            "sphinx.ext.todo,"
-            "sphinx.ext.viewcode,"
-            "recommonmark"
-        ),
-        "-b",
-        "html",
-        "-d",
-        os.path.join("docs", "_build", "doctrees", ""),
-        os.path.join("docs", ""),
-        os.path.join("docs", "_build", "html", ""),
-    )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ description = "Google Cloud Firestore API client library"
 version = "1.9.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "pytz",
 ]


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to the protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566