### PR TITLE
fix: Use unittest.mock if available

### DIFF
--- a/tests/unit/gapic/firestore_admin_v1/test_firestore_admin.py
+++ b/tests/unit/gapic/firestore_admin_v1/test_firestore_admin.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/unit/gapic/firestore_v1/test_firestore.py
+++ b/tests/unit/gapic/firestore_v1/test_firestore.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/unit/v1/_test_helpers.py
+++ b/tests/unit/v1/_test_helpers.py
@@ -14,7 +14,10 @@
 
 import concurrent.futures
 import datetime
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import typing
 
 import google

--- a/tests/unit/v1/test__helpers.py
+++ b/tests/unit/v1/test__helpers.py
@@ -15,7 +15,10 @@
 
 import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_async_batch.py
+++ b/tests/unit/v1/test_async_batch.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test__helpers import AsyncMock

--- a/tests/unit/v1/test_async_client.py
+++ b/tests/unit/v1/test_async_client.py
@@ -15,7 +15,10 @@
 import datetime
 import types
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test__helpers import AsyncIter

--- a/tests/unit/v1/test_async_collection.py
+++ b/tests/unit/v1/test_async_collection.py
@@ -14,7 +14,10 @@
 
 import types
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test__helpers import AsyncIter

--- a/tests/unit/v1/test_async_document.py
+++ b/tests/unit/v1/test_async_document.py
@@ -14,7 +14,10 @@
 
 import collections
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test__helpers import AsyncIter, AsyncMock

--- a/tests/unit/v1/test_async_query.py
+++ b/tests/unit/v1/test_async_query.py
@@ -14,7 +14,10 @@
 
 import types
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test__helpers import AsyncIter

--- a/tests/unit/v1/test_async_transaction.py
+++ b/tests/unit/v1/test_async_transaction.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test__helpers import AsyncMock

--- a/tests/unit/v1/test_base_batch.py
+++ b/tests/unit/v1/test_base_batch.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 def _make_derived_write_batch(*args, **kwargs):

--- a/tests/unit/v1/test_base_client.py
+++ b/tests/unit/v1/test_base_client.py
@@ -15,7 +15,10 @@
 import datetime
 import grpc
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 PROJECT = "my-prahjekt"

--- a/tests/unit/v1/test_base_collection.py
+++ b/tests/unit/v1/test_base_collection.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_base_document.py
+++ b/tests/unit/v1/test_base_document.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -14,7 +14,10 @@
 
 import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_base_transaction.py
+++ b/tests/unit/v1/test_base_transaction.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_batch.py
+++ b/tests/unit/v1/test_batch.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_bulk_batch.py
+++ b/tests/unit/v1/test_bulk_batch.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 def _make_bulk_write_batch(*args, **kwargs):

--- a/tests/unit/v1/test_bulk_writer.py
+++ b/tests/unit/v1/test_bulk_writer.py
@@ -16,7 +16,10 @@ import datetime
 from typing import List, NoReturn, Optional, Tuple, Type
 
 import aiounittest  # type: ignore
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from google.cloud.firestore_v1 import async_client

--- a/tests/unit/v1/test_bundle.py
+++ b/tests/unit/v1/test_bundle.py
@@ -16,7 +16,10 @@
 
 import typing
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from google.cloud.firestore_v1 import base_query

--- a/tests/unit/v1/test_client.py
+++ b/tests/unit/v1/test_client.py
@@ -15,7 +15,10 @@
 import datetime
 import types
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_collection.py
+++ b/tests/unit/v1/test_collection.py
@@ -14,7 +14,10 @@
 
 import types
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 def _make_collection_reference(*args, **kwargs):

--- a/tests/unit/v1/test_cross_language.py
+++ b/tests/unit/v1/test_cross_language.py
@@ -17,7 +17,10 @@ import glob
 import json
 import os
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from google.cloud.firestore_v1.types import document

--- a/tests/unit/v1/test_document.py
+++ b/tests/unit/v1/test_document.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_field_path.py
+++ b/tests/unit/v1/test_field_path.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_order.py
+++ b/tests/unit/v1/test_order.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_query.py
+++ b/tests/unit/v1/test_query.py
@@ -14,7 +14,10 @@
 
 import types
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 from tests.unit.v1.test_base_query import _make_credentials

--- a/tests/unit/v1/test_rate_limiter.py
+++ b/tests/unit/v1/test_rate_limiter.py
@@ -14,7 +14,10 @@
 
 import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 # Pick a point in time as the center of our universe for this test run.

--- a/tests/unit/v1/test_transaction.py
+++ b/tests/unit/v1/test_transaction.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 

--- a/tests/unit/v1/test_watch.py
+++ b/tests/unit/v1/test_watch.py
@@ -14,7 +14,10 @@
 
 import datetime
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 


### PR DESCRIPTION
The `mock` module is deprecated in recent Python versions.

Signed-off-by: Major Hayden <major@mhtx.net>

Fixes #576 🦕
