### PR TITLE
fix(deps): Require proto-plus >=1.20.5

### DIFF
--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -1209,7 +1209,7 @@ def deserialize_bundle(
             bundle_element: BundleElement = BundleElement.from_json(json.dumps(data))  # type: ignore
         except AttributeError as e:
             # Some bad serialization formats cannot be universally deserialized.
-            if e.args[0] == "'dict' object has no attribute 'find'":
+            if e.args[0] == "'dict' object has no attribute 'find'":  # pragma: NO COVER
                 raise ValueError(
                     "Invalid serialization of datetimes. "
                     "Cannot deserialize Bundles created from the NodeJS SDK."

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-cloud-core >= 1.4.1, <3.0.0dev",
-    "proto-plus >= 1.20.5",
+    "proto-plus >= 1.20.5, <2.0.0dev",
 ]
 extras = {}
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-cloud-core >= 1.4.1, <3.0.0dev",
-    "proto-plus >= 1.10.0",
+    "proto-plus >= 1.20.5",
 ]
 extras = {}
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -7,5 +7,5 @@
 # Then this file should have foo==1.14.0
 google-api-core==1.31.5
 google-cloud-core==1.4.1
-proto-plus==1.10.0
+proto-plus==1.20.5
 protobuf==3.12.0  # transitive from `google-api-core`

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,4 +8,4 @@
 google-api-core==1.31.5
 google-cloud-core==1.4.1
 proto-plus==1.20.5
-protobuf==3.12.0  # transitive from `google-api-core`
+protobuf==3.19.0  # transitive from `google-api-core`


### PR DESCRIPTION
In proto-plus 1.20.5, the protobuf dependency is pinned to <4.0.0dev

Fix #592

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
