### PR TITLE
fix: ordering in limit_to_last

### DIFF
--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -160,7 +160,7 @@ class Query(BaseQuery):
             for order in self._orders:
                 order.direction = _enum_from_direction(
                     self.DESCENDING
-                    if order.direction == self.ASCENDING
+                    if order.direction.name == self.ASCENDING
                     else self.ASCENDING
                 )
             self._limit_to_last = False


### PR DESCRIPTION
When limit_to_last was set, we need to reverse the order. However due to error in comparing the order direction, it was not properly set.

comparing `order.direction == self.ASCENDING` is always `False` because there are two different types.

The correct way is by comparing `order.direction.name == self.ASCENDING`

Fixes #536

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
