### PR TITLE
feat: OR Query implementation

### DIFF
--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -343,7 +343,7 @@ class BaseQuery(object):
         """
         field_paths = list(field_paths)
         for field_path in field_paths:
-            field_path_module.split_field_path(field_path)  # raises
+            field_path_module.split_field_path(field_path)
 
         new_projection = query.StructuredQuery.Projection(
             fields=[

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -439,7 +439,7 @@ class BaseQuery(object):
                 "'Or' and 'And' objects must be passed using keyword argument 'filter'"
             )
 
-        field_path_module.split_field_path(field_path)  # raises
+        field_path_module.split_field_path(field_path)
         new_filters = self._field_filters
 
         if field_path is not None and op_string is not None:

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -20,8 +20,10 @@ a more common way to create a query than direct usage of the constructor.
 """
 from __future__ import annotations
 
+import abc
 import copy
 import math
+import warnings
 
 from google.api_core import retry as retries
 from google.protobuf import wrappers_pb2
@@ -99,6 +101,104 @@ _NO_ORDERS_FOR_CURSOR = (
 _MISMATCH_CURSOR_W_ORDER_BY = "The cursor {!r} does not match the order fields {!r}."
 
 _not_passed = object()
+
+
+class BaseFilter(abc.ABC):
+    """Base class for Filters"""
+
+    @abc.abstractmethod
+    def _to_pb(self):
+        """Build the protobuf representation based on values in the filter"""
+
+
+class FieldFilter(BaseFilter):
+    """Class representation of a Field Filter."""
+
+    def __init__(self, field_path, op_string, value=None):
+        self.field_path = field_path
+        self.value = value
+
+        if value is None:
+            if op_string != _EQ_OP:
+                raise ValueError(_BAD_OP_NAN_NULL)
+            self.op_string = StructuredQuery.UnaryFilter.Operator.IS_NULL
+
+        elif _isnan(value):
+            if op_string != _EQ_OP:
+                raise ValueError(_BAD_OP_NAN_NULL)
+            self.op_string = StructuredQuery.UnaryFilter.Operator.IS_NAN
+        elif isinstance(value, (transforms.Sentinel, transforms._ValueList)):
+            raise ValueError(_INVALID_WHERE_TRANSFORM)
+        else:
+            self.op_string = op_string
+
+    def _to_pb(self):
+        """Returns the protobuf representation, either a StructuredQuery.UnaryFilter or a StructuredQuery.FieldFilter"""
+        if self.value is None or _isnan(self.value):
+            filter_pb = query.StructuredQuery.UnaryFilter(
+                field=query.StructuredQuery.FieldReference(field_path=self.field_path),
+                op=self.op_string,
+            )
+        else:
+            filter_pb = query.StructuredQuery.FieldFilter(
+                field=query.StructuredQuery.FieldReference(field_path=self.field_path),
+                op=_enum_from_op_string(self.op_string),
+                value=_helpers.encode_value(self.value),
+            )
+        return filter_pb
+
+
+class BaseCompositeFilter(BaseFilter):
+    """Base class for a Composite Filter. (either OR or AND)."""
+
+    def __init__(
+        self,
+        operator=StructuredQuery.CompositeFilter.Operator.OPERATOR_UNSPECIFIED,
+        filters=None,
+    ):
+        self.operator = operator
+        if filters is None:
+            self.filters = []
+        else:
+            self.filters = filters
+
+    def __repr__(self):
+        repr = f"op: {self.operator}\nFilters:"
+        for filter in self.filters:
+            repr += f"\n\t{filter}"
+        return repr
+
+    def _to_pb(self):
+        """Build the protobuf representation based on values in the Composite Filter."""
+        filter_pb = StructuredQuery.CompositeFilter(
+            op=self.operator,
+        )
+        for filter in self.filters:
+            if isinstance(filter, BaseCompositeFilter):
+                fb = query.StructuredQuery.Filter(composite_filter=filter._to_pb())
+            else:
+                fb = _filter_pb(filter._to_pb())
+            filter_pb.filters.append(fb)
+
+        return filter_pb
+
+
+class Or(BaseCompositeFilter):
+    """Class representation of an OR Filter."""
+
+    def __init__(self, filters):
+        super().__init__(
+            operator=StructuredQuery.CompositeFilter.Operator.OR, filters=filters
+        )
+
+
+class And(BaseCompositeFilter):
+    """Class representation of an AND Filter."""
+
+    def __init__(self, filters):
+        super().__init__(
+            operator=StructuredQuery.CompositeFilter.Operator.AND, filters=filters
+        )
 
 
 class BaseQuery(object):
@@ -288,7 +388,14 @@ class BaseQuery(object):
         copy instead of being misinterpreted as an unpassed parameter."""
         return value if value is not _not_passed else fallback_value
 
-    def where(self, field_path: str, op_string: str, value) -> "BaseQuery":
+    def where(
+        self,
+        field_path: Optional[str] = None,
+        op_string: Optional[str] = None,
+        value=None,
+        *,
+        filter=None,
+    ) -> "BaseQuery":
         """Filter the query on a field.
 
         See :meth:`~google.cloud.firestore_v1.client.Client.field_path` for
@@ -300,9 +407,9 @@ class BaseQuery(object):
         operation.
 
         Args:
-            field_path (str): A field path (``.``-delimited list of
+            field_path (Optional[str]): A field path (``.``-delimited list of
                 field names) for the field to filter on.
-            op_string (str): A comparison operation in the form of a string.
+            op_string (Optional[str]): A comparison operation in the form of a string.
                 Acceptable values are ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``,
                 ``in``, ``not-in``, ``array_contains`` and ``array_contains_any``.
             value (Any): The value to compare the field against in the filter.
@@ -315,36 +422,66 @@ class BaseQuery(object):
             modified with the newly added filter.
 
         Raises:
-            ValueError: If ``field_path`` is invalid.
-            ValueError: If ``value`` is a NaN or :data:`None` and
-                ``op_string`` is not ``==``.
+            ValueError: If
+                * ``field_path`` is invalid.
+                * If ``value`` is a NaN or :data:`None` and ``op_string`` is not ``==``.
+                * FieldFilter was passed without using the filter keyword argument.
+                * `And` or `Or` was passed without using the filter keyword argument .
+                * Both the positional arguments and the keyword argument `filter` were passed.
         """
+
+        if isinstance(field_path, FieldFilter):
+            raise ValueError(
+                "FieldFilter object must be passed using keyword argument 'filter'"
+            )
+        if isinstance(field_path, BaseCompositeFilter):
+            raise ValueError(
+                "'Or' and 'And' objects must be passed using keyword argument 'filter'"
+            )
+
         field_path_module.split_field_path(field_path)  # raises
+        new_filters = self._field_filters
 
-        if value is None:
-            if op_string != _EQ_OP:
-                raise ValueError(_BAD_OP_NAN_NULL)
-            filter_pb = query.StructuredQuery.UnaryFilter(
-                field=query.StructuredQuery.FieldReference(field_path=field_path),
-                op=StructuredQuery.UnaryFilter.Operator.IS_NULL,
+        if field_path is not None and op_string is not None:
+            if filter is not None:
+                raise ValueError(
+                    "Can't pass in both the positional arguments and 'filter' at the same time"
+                )
+            warnings.warn(
+                "Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead.",
+                UserWarning,
+                stacklevel=2,
             )
-        elif _isnan(value):
-            if op_string != _EQ_OP:
-                raise ValueError(_BAD_OP_NAN_NULL)
-            filter_pb = query.StructuredQuery.UnaryFilter(
-                field=query.StructuredQuery.FieldReference(field_path=field_path),
-                op=StructuredQuery.UnaryFilter.Operator.IS_NAN,
-            )
-        elif isinstance(value, (transforms.Sentinel, transforms._ValueList)):
-            raise ValueError(_INVALID_WHERE_TRANSFORM)
+            if value is None:
+                if op_string != _EQ_OP:
+                    raise ValueError(_BAD_OP_NAN_NULL)
+                filter_pb = query.StructuredQuery.UnaryFilter(
+                    field=query.StructuredQuery.FieldReference(field_path=field_path),
+                    op=StructuredQuery.UnaryFilter.Operator.IS_NULL,
+                )
+            elif _isnan(value):
+                if op_string != _EQ_OP:
+                    raise ValueError(_BAD_OP_NAN_NULL)
+                filter_pb = query.StructuredQuery.UnaryFilter(
+                    field=query.StructuredQuery.FieldReference(field_path=field_path),
+                    op=StructuredQuery.UnaryFilter.Operator.IS_NAN,
+                )
+            elif isinstance(value, (transforms.Sentinel, transforms._ValueList)):
+                raise ValueError(_INVALID_WHERE_TRANSFORM)
+            else:
+                filter_pb = query.StructuredQuery.FieldFilter(
+                    field=query.StructuredQuery.FieldReference(field_path=field_path),
+                    op=_enum_from_op_string(op_string),
+                    value=_helpers.encode_value(value),
+                )
+
+            new_filters += (filter_pb,)
+        elif isinstance(filter, BaseFilter):
+            new_filters += (filter._to_pb(),)
         else:
-            filter_pb = query.StructuredQuery.FieldFilter(
-                field=query.StructuredQuery.FieldReference(field_path=field_path),
-                op=_enum_from_op_string(op_string),
-                value=_helpers.encode_value(value),
+            raise ValueError(
+                "Filter must be provided through positional arguments or the 'filter' keyword argument."
             )
-
-        new_filters = self._field_filters + (filter_pb,)
         return self._copy(field_filters=new_filters)
 
     @staticmethod
@@ -651,7 +788,7 @@ class BaseQuery(object):
             document_fields_or_snapshot, before=False, start=False
         )
 
-    def _filters_pb(self) -> StructuredQuery.Filter:
+    def _filters_pb(self) -> Optional[StructuredQuery.Filter]:
         """Convert all the filters into a single generic Filter protobuf.
 
         This may be a lone field filter or unary filter, may be a composite
@@ -665,12 +802,24 @@ class BaseQuery(object):
         if num_filters == 0:
             return None
         elif num_filters == 1:
-            return _filter_pb(self._field_filters[0])
+            filter = self._field_filters[0]
+            if isinstance(filter, query.StructuredQuery.CompositeFilter):
+                return query.StructuredQuery.Filter(composite_filter=filter)
+            else:
+                return _filter_pb(filter)
         else:
+
             composite_filter = query.StructuredQuery.CompositeFilter(
                 op=StructuredQuery.CompositeFilter.Operator.AND,
-                filters=[_filter_pb(filter_) for filter_ in self._field_filters],
             )
+            for filter_ in self._field_filters:
+                if isinstance(filter_, query.StructuredQuery.CompositeFilter):
+                    composite_filter.filters.append(
+                        query.StructuredQuery.Filter(composite_filter=filter_)
+                    )
+                else:
+                    composite_filter.filters.append(_filter_pb(filter_))
+
             return query.StructuredQuery.Filter(composite_filter=composite_filter)
 
     @staticmethod
@@ -726,7 +875,7 @@ class BaseQuery(object):
     def _normalize_cursor(self, cursor, orders) -> Optional[Tuple[Any, Any]]:
         """Helper: convert cursor to a list of values based on orders."""
         if cursor is None:
-            return
+            return None
 
         if not orders:
             raise ValueError(_NO_ORDERS_FOR_CURSOR)
@@ -817,16 +966,16 @@ class BaseQuery(object):
     def get(
         self,
         transaction=None,
-        retry: retries.Retry = None,
-        timeout: float = None,
+        retry: Optional[retries.Retry] = None,
+        timeout: Optional[float] = None,
     ) -> Iterable[DocumentSnapshot]:
         raise NotImplementedError
 
     def _prep_stream(
         self,
         transaction=None,
-        retry: retries.Retry = None,
-        timeout: float = None,
+        retry: Optional[retries.Retry] = None,
+        timeout: Optional[float] = None,
     ) -> Tuple[dict, str, dict]:
         """Shared setup for async / sync :meth:`stream`"""
         if self._limit_to_last:
@@ -848,8 +997,8 @@ class BaseQuery(object):
     def stream(
         self,
         transaction=None,
-        retry: retries.Retry = None,
-        timeout: float = None,
+        retry: Optional[retries.Retry] = None,
+        timeout: Optional[float] = None,
     ) -> Generator[document.DocumentSnapshot, Any, None]:
         raise NotImplementedError
 
@@ -1195,8 +1344,8 @@ class BaseCollectionGroup(BaseQuery):
     def _prep_get_partitions(
         self,
         partition_count,
-        retry: retries.Retry = None,
-        timeout: float = None,
+        retry: Optional[retries.Retry] = None,
+        timeout: Optional[float] = None,
     ) -> Tuple[dict, dict]:
         self._validate_partition_query()
         parent_path, expected_prefix = self._parent._parent_info()
@@ -1220,8 +1369,8 @@ class BaseCollectionGroup(BaseQuery):
     def get_partitions(
         self,
         partition_count,
-        retry: retries.Retry = None,
-        timeout: float = None,
+        retry: Optional[retries.Retry] = None,
+        timeout: Optional[float] = None,
     ) -> NoReturn:
         raise NotImplementedError
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1919,7 +1919,10 @@ def test_query_with_complex_composite_filter(query_docs):
 
     # b == 3 || (stats.sum == 4  && a == 4)
     comp_filter = Or(
-        filters=[FieldFilter("b", "==", 3), And([FieldFilter("stats.sum", "==", 4), FieldFilter("a", "==", 4)])]
+        filters=[
+            FieldFilter("b", "==", 3),
+            And([FieldFilter("stats.sum", "==", 4), FieldFilter("a", "==", 4)]),
+        ]
     )
     query = collection.where(filter=comp_filter)
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -548,6 +548,21 @@ def query(query_docs):
     return query
 
 
+def test_query_stream_legacy_where(query_docs):
+    """Assert the legacy code still works and returns value"""
+    collection, stored, allowed_vals = query_docs
+    with pytest.warns(
+        UserWarning,
+        match="Detected filter using positional arguments",
+    ):
+        query = collection.where("a", "==", 1)
+        values = {snapshot.id: snapshot.to_dict() for snapshot in query.stream()}
+        assert len(values) == len(allowed_vals)
+        for key, value in values.items():
+            assert stored[key] == value
+            assert value["a"] == 1
+
+
 def test_query_stream_w_simple_field_eq_op(query_docs):
     collection, stored, allowed_vals = query_docs
     query = collection.where(filter=FieldFilter("a", "==", 1))

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1901,6 +1901,7 @@ def test_query_with_complex_composite_filter(query_docs):
     or_filter = Or(
         filters=[FieldFilter("stats.sum", "==", 0), FieldFilter("stats.sum", "==", 4)]
     )
+    # b == 0 && (stats.sum == 0 || stats.sum == 4)
     query = collection.where(filter=field_filter).where(filter=or_filter)
 
     sum_0 = 0
@@ -1915,6 +1916,25 @@ def test_query_with_complex_composite_filter(query_docs):
 
     assert sum_0 > 0
     assert sum_4 > 0
+
+    # b == 3 || (stats.sum == 4  && a == 4)
+    comp_filter = Or(
+        filters=[FieldFilter("b", "==", 3), And([FieldFilter("stats.sum", "==", 4), FieldFilter("a", "==", 4)])]
+    )
+    query = collection.where(filter=comp_filter)
+
+    b_3 = False
+    b_not_3 = False
+    for result in query.stream():
+        if result.get("b") == 3:
+            b_3 = True
+        else:
+            b_not_3 = True
+            assert result.get("stats.sum") == 4
+            assert result.get("a") == 4
+
+    assert b_3 is True
+    assert b_not_3 is True
 
 
 def test_or_query_in_transaction(client, cleanup):

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -592,6 +592,21 @@ async def async_query(query_docs):
     return query
 
 
+async def test_query_stream_legacy_where(query_docs):
+    """Assert the legacy code still works and returns value, and shows UserWarning"""
+    collection, stored, allowed_vals = query_docs
+    with pytest.warns(
+        UserWarning,
+        match="Detected filter using positional arguments",
+    ):
+        query = collection.where("a", "==", 1)
+        values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
+        assert len(values) == len(allowed_vals)
+        for key, value in values.items():
+            assert stored[key] == value
+            assert value["a"] == 1
+
+
 async def test_query_stream_w_simple_field_eq_op(query_docs):
     collection, stored, allowed_vals = query_docs
     query = collection.where(filter=FieldFilter("a", "==", 1))

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1604,7 +1604,7 @@ async def test_count_query_in_transaction(client, cleanup):
 
     with pytest.raises(ValueError) as exc:
         await create_in_transaction_helper(transaction, client, collection_id, cleanup)
-        assert exc.exc_info == "Collection can't have more than 2 documents"
+    assert str(exc.value) == "Collection can't have more than 2 docs"
 
     collection = client.collection(collection_id)
 
@@ -1643,7 +1643,6 @@ async def test_query_with_or_composite_filter(query_docs):
     lt_10 = 0
     async for result in query.stream():
         value = result.get("stats.product")
-        print(value)
         assert value > 5 or value < 10
         if value > 5:
             gt_5 += 1
@@ -1665,8 +1664,6 @@ async def test_query_with_complex_composite_filter(query_docs):
     sum_0 = 0
     sum_4 = 0
     async for result in query.stream():
-        value = result.to_dict()
-        assert value["b"] == 0
         assert result.get("b") == 0
         assert result.get("stats.sum") == 0 or result.get("stats.sum") == 4
         if result.get("stats.sum") == 0:
@@ -1676,3 +1673,47 @@ async def test_query_with_complex_composite_filter(query_docs):
 
     assert sum_0 > 0
     assert sum_4 > 0
+
+
+async def test_or_query_in_transaction(client, cleanup):
+    collection_id = "doc-create" + UNIQUE_RESOURCE_ID
+    document_id_1 = "doc1" + UNIQUE_RESOURCE_ID
+    document_id_2 = "doc2" + UNIQUE_RESOURCE_ID
+
+    document_1 = client.document(collection_id, document_id_1)
+    document_2 = client.document(collection_id, document_id_2)
+
+    cleanup(document_1.delete)
+    cleanup(document_2.delete)
+
+    await document_1.create({"a": 1, "b": 2})
+    await document_2.create({"a": 1, "b": 1})
+
+    transaction = client.transaction()
+
+    with pytest.raises(ValueError) as exc:
+        await create_in_transaction_helper(transaction, client, collection_id, cleanup)
+    assert str(exc.value) == "Collection can't have more than 2 docs"
+
+    collection = client.collection(collection_id)
+
+    query = collection.where(filter=FieldFilter("a", "==", 1)).where(
+        filter=Or([FieldFilter("b", "==", 1), FieldFilter("b", "==", 2)])
+    )
+    b_1 = False
+    b_2 = False
+    count = 0
+    async for result in query.stream():
+        assert result.get("a") == 1  # assert a==1 is True in both results
+        assert result.get("b") == 1 or result.get("b") == 2
+        if result.get("b") == 1:
+            b_1 = True
+        if result.get("b") == 2:
+            b_2 = True
+        count += 1
+
+    assert b_1 is True  # assert one of them is b == 1
+    assert b_2 is True  # assert one of them is b == 2
+    assert (
+        count == 2
+    )  # assert only 2 results, the third one was rolledback and not created

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1677,7 +1677,10 @@ async def test_query_with_complex_composite_filter(query_docs):
 
     # b == 3 || (stats.sum == 4  && a == 4)
     comp_filter = Or(
-        filters=[FieldFilter("b", "==", 3), And([FieldFilter("stats.sum", "==", 4), FieldFilter("a", "==", 4)])]
+        filters=[
+            FieldFilter("b", "==", 3),
+            And([FieldFilter("stats.sum", "==", 4), FieldFilter("a", "==", 4)]),
+        ]
     )
     query = collection.where(filter=comp_filter)
 

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -35,6 +35,7 @@ from google.api_core.exceptions import NotFound
 from google.cloud._helpers import _datetime_to_pb_timestamp
 from google.cloud._helpers import UTC
 from google.cloud import firestore_v1 as firestore
+from google.cloud.firestore_v1.base_query import FieldFilter, And, Or
 
 from tests.system.test__helpers import (
     FIRESTORE_CREDS,
@@ -586,14 +587,14 @@ async def query_docs(client):
 @pytest_asyncio.fixture
 async def async_query(query_docs):
     collection, stored, allowed_vals = query_docs
-    query = collection.where("a", "==", 1)
+    query = collection.where(filter=FieldFilter("a", "==", 1))
 
     return query
 
 
 async def test_query_stream_w_simple_field_eq_op(query_docs):
     collection, stored, allowed_vals = query_docs
-    query = collection.where("a", "==", 1)
+    query = collection.where(filter=FieldFilter("a", "==", 1))
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     assert len(values) == len(allowed_vals)
     for key, value in values.items():
@@ -603,7 +604,7 @@ async def test_query_stream_w_simple_field_eq_op(query_docs):
 
 async def test_query_stream_w_simple_field_array_contains_op(query_docs):
     collection, stored, allowed_vals = query_docs
-    query = collection.where("c", "array_contains", 1)
+    query = collection.where(filter=FieldFilter("c", "array_contains", 1))
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     assert len(values) == len(allowed_vals)
     for key, value in values.items():
@@ -614,7 +615,7 @@ async def test_query_stream_w_simple_field_array_contains_op(query_docs):
 async def test_query_stream_w_simple_field_in_op(query_docs):
     collection, stored, allowed_vals = query_docs
     num_vals = len(allowed_vals)
-    query = collection.where("a", "in", [1, num_vals + 100])
+    query = collection.where(filter=FieldFilter("a", "in", [1, num_vals + 100]))
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     assert len(values) == len(allowed_vals)
     for key, value in values.items():
@@ -625,7 +626,9 @@ async def test_query_stream_w_simple_field_in_op(query_docs):
 async def test_query_stream_w_simple_field_array_contains_any_op(query_docs):
     collection, stored, allowed_vals = query_docs
     num_vals = len(allowed_vals)
-    query = collection.where("c", "array_contains_any", [1, num_vals * 200])
+    query = collection.where(
+        filter=FieldFilter("c", "array_contains_any", [1, num_vals * 200])
+    )
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     assert len(values) == len(allowed_vals)
     for key, value in values.items():
@@ -648,7 +651,7 @@ async def test_query_stream_w_order_by(query_docs):
 
 async def test_query_stream_w_field_path(query_docs):
     collection, stored, allowed_vals = query_docs
-    query = collection.where("stats.sum", ">", 4)
+    query = collection.where(filter=FieldFilter("stats.sum", ">", 4))
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     assert len(values) == 10
     ab_pairs2 = set()
@@ -685,7 +688,7 @@ async def test_query_stream_w_start_end_cursor(query_docs):
 async def test_query_stream_wo_results(query_docs):
     collection, stored, allowed_vals = query_docs
     num_vals = len(allowed_vals)
-    query = collection.where("b", "==", num_vals + 100)
+    query = collection.where(filter=FieldFilter("b", "==", num_vals + 100))
     values = [i async for i in query.stream()]
     assert len(values) == 0
 
@@ -693,7 +696,9 @@ async def test_query_stream_wo_results(query_docs):
 async def test_query_stream_w_projection(query_docs):
     collection, stored, allowed_vals = query_docs
     num_vals = len(allowed_vals)
-    query = collection.where("b", "<=", 1).select(["a", "stats.product"])
+    query = collection.where(filter=FieldFilter("b", "<=", 1)).select(
+        ["a", "stats.product"]
+    )
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     assert len(values) == num_vals * 2  # a ANY, b in (0, 1)
     for key, value in values.items():
@@ -706,7 +711,9 @@ async def test_query_stream_w_projection(query_docs):
 
 async def test_query_stream_w_multiple_filters(query_docs):
     collection, stored, allowed_vals = query_docs
-    query = collection.where("stats.product", ">", 5).where("stats.product", "<", 10)
+    query = collection.where(filter=FieldFilter("stats.product", ">", 5)).where(
+        "stats.product", "<", 10
+    )
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     matching_pairs = [
         (a_val, b_val)
@@ -725,7 +732,7 @@ async def test_query_stream_w_offset(query_docs):
     collection, stored, allowed_vals = query_docs
     num_vals = len(allowed_vals)
     offset = 3
-    query = collection.where("b", "==", 2).offset(offset)
+    query = collection.where(filter=FieldFilter("b", "==", 2)).offset(offset)
     values = {snapshot.id: snapshot.to_dict() async for snapshot in query.stream()}
     # NOTE: We don't check the ``a``-values, since that would require
     #       an ``order_by('a')``, which combined with the ``b == 2``
@@ -790,7 +797,7 @@ async def test_query_unary(client, cleanup):
     cleanup(document1.delete)
 
     # 0. Query for null.
-    query0 = collection.where(field_name, "==", None)
+    query0 = collection.where(filter=FieldFilter(field_name, "==", None))
     values0 = [i async for i in query0.stream()]
     assert len(values0) == 1
     snapshot0 = values0[0]
@@ -798,7 +805,7 @@ async def test_query_unary(client, cleanup):
     assert snapshot0.to_dict() == {field_name: None}
 
     # 1. Query for a NAN.
-    query1 = collection.where(field_name, "==", nan_val)
+    query1 = collection.where(filter=FieldFilter(field_name, "==", nan_val))
     values1 = [i async for i in query1.stream()]
     assert len(values1) == 1
     snapshot1 = values1[0]
@@ -907,10 +914,18 @@ async def test_collection_group_queries_filters(client, cleanup):
     query = (
         client.collection_group(collection_group)
         .where(
-            firestore.field_path.FieldPath.document_id(), ">=", client.document("a/b")
+            filter=FieldFilter(
+                firestore.field_path.FieldPath.document_id(),
+                ">=",
+                client.document("a/b"),
+            )
         )
         .where(
-            firestore.field_path.FieldPath.document_id(), "<=", client.document("a/b0")
+            filter=FieldFilter(
+                firestore.field_path.FieldPath.document_id(),
+                "<=",
+                client.document("a/b0"),
+            )
         )
     )
     snapshots = [i async for i in query.stream()]
@@ -920,12 +935,18 @@ async def test_collection_group_queries_filters(client, cleanup):
     query = (
         client.collection_group(collection_group)
         .where(
-            firestore.field_path.FieldPath.document_id(), ">", client.document("a/b")
+            filter=FieldFilter(
+                firestore.field_path.FieldPath.document_id(),
+                ">",
+                client.document("a/b"),
+            )
         )
         .where(
-            firestore.field_path.FieldPath.document_id(),
-            "<",
-            client.document("a/b/{}/cg-doc3".format(collection_group)),
+            filter=FieldFilter(
+                firestore.field_path.FieldPath.document_id(),
+                "<",
+                client.document("a/b/{}/cg-doc3".format(collection_group)),
+            )
         )
     )
     snapshots = [i async for i in query.stream()]
@@ -1551,7 +1572,7 @@ async def test_async_count_query_stream_empty_aggregation(async_query):
 @firestore.async_transactional
 async def create_in_transaction_helper(transaction, client, collection_id, cleanup):
     collection = client.collection(collection_id)
-    query = collection.where("a", "==", 1)
+    query = collection.where(filter=FieldFilter("a", "==", 1))
     count_query = query.count()
     result = await count_query.get(transaction=transaction)
 
@@ -1587,8 +1608,71 @@ async def test_count_query_in_transaction(client, cleanup):
 
     collection = client.collection(collection_id)
 
-    query = collection.where("a", "==", 1)
+    query = collection.where(filter=FieldFilter("a", "==", 1))
     count_query = query.count()
     result = await count_query.get()
     for r in result[0]:
         assert r.value == 2  # there are still only 2 docs
+
+
+async def test_query_with_and_composite_filter(query_docs):
+    collection, stored, allowed_vals = query_docs
+    and_filter = And(
+        filters=[
+            FieldFilter("stats.product", ">", 5),
+            FieldFilter("stats.product", "<", 10),
+        ]
+    )
+
+    query = collection.where(filter=and_filter)
+    async for result in query.stream():
+        assert result.get("stats.product") > 5
+        assert result.get("stats.product") < 10
+
+
+async def test_query_with_or_composite_filter(query_docs):
+    collection, stored, allowed_vals = query_docs
+    or_filter = Or(
+        filters=[
+            FieldFilter("stats.product", ">", 5),
+            FieldFilter("stats.product", "<", 10),
+        ]
+    )
+    query = collection.where(filter=or_filter)
+    gt_5 = 0
+    lt_10 = 0
+    async for result in query.stream():
+        value = result.get("stats.product")
+        print(value)
+        assert value > 5 or value < 10
+        if value > 5:
+            gt_5 += 1
+        if value < 10:
+            lt_10 += 1
+
+    assert gt_5 > 0
+    assert lt_10 > 0
+
+
+async def test_query_with_complex_composite_filter(query_docs):
+    collection, stored, allowed_vals = query_docs
+    field_filter = FieldFilter("b", "==", 0)
+    or_filter = Or(
+        filters=[FieldFilter("stats.sum", "==", 0), FieldFilter("stats.sum", "==", 4)]
+    )
+    query = collection.where(filter=field_filter).where(filter=or_filter)
+
+    sum_0 = 0
+    sum_4 = 0
+    async for result in query.stream():
+        value = result.to_dict()
+        assert value["b"] == 0
+        assert result.get("b") == 0
+        assert result.get("stats.sum") == 0 or result.get("stats.sum") == 4
+        if result.get("stats.sum") == 0:
+            sum_0 += 1
+        if result.get("stats.sum") == 4:
+            sum_4 += 1
+
+    assert sum_0 > 0
+    assert sum_4 > 0

--- a/tests/unit/v1/test_base_collection.py
+++ b/tests/unit/v1/test_base_collection.py
@@ -220,6 +220,48 @@ def test_basecollectionreference_where(mock_query):
 
 
 @mock.patch("google.cloud.firestore_v1.base_query.BaseQuery", autospec=True)
+def test_basecollectionreference_where_with_filter_arg(mock_query):
+    from google.cloud.firestore_v1.base_collection import BaseCollectionReference
+    from google.cloud.firestore_v1.base_query import FieldFilter
+
+    with mock.patch.object(BaseCollectionReference, "_query") as _query:
+        _query.return_value = mock_query
+
+        collection = _make_base_collection_reference("collection")
+        field_path = "foo"
+        op_string = "=="
+        value = 45
+        field_filter = FieldFilter(field_path, op_string, value)
+        query = collection.where(filter=field_filter)
+
+        mock_query.where.assert_called_once_with(filter=field_filter)
+        assert query == mock_query.where.return_value
+
+
+@mock.patch("google.cloud.firestore_v1.base_query.BaseQuery", autospec=True)
+def test_basecollectionreference_where_with_filter_arg_and_positional_args(mock_query):
+    from google.cloud.firestore_v1.base_collection import BaseCollectionReference
+    from google.cloud.firestore_v1.base_query import FieldFilter
+
+    with mock.patch.object(BaseCollectionReference, "_query") as _query:
+        _query.return_value = mock_query
+
+        collection = _make_base_collection_reference("collection")
+        field_path = "foo"
+        op_string = "=="
+        value = 45
+        field_filter = FieldFilter(field_path, op_string, value)
+        with pytest.raises(ValueError) as exc:
+            collection.where(field_path, op_string, value, filter=field_filter)
+
+        mock_query.where.assert_not_called()
+        assert (
+            str(exc.value)
+            == "Can't pass in both the positional arguments and 'filter' at the same time"
+        )
+
+
+@mock.patch("google.cloud.firestore_v1.base_query.BaseQuery", autospec=True)
 def test_basecollectionreference_where_w___name___w_value_as_list_of_str(mock_query):
     from google.cloud.firestore_v1.base_collection import BaseCollectionReference
 

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -289,18 +289,32 @@ def _where_unary_helper_field_filter(value, op_enum, op_string="=="):
     _compare_queries(query_inst, new_query, "_field_filters")
 
 
-def test_basequery_where_eq_null():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_eq_null(unary_helper_function):
     from google.cloud.firestore_v1.types import StructuredQuery
 
     op_enum = StructuredQuery.UnaryFilter.Operator.IS_NULL
-    _where_unary_helper(None, op_enum)
+    unary_helper_function(None, op_enum)
 
 
-def test_basequery_where_gt_null():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_gt_null(unary_helper_function):
     from google.cloud.firestore_v1.base_query import _BAD_OP_NAN_NULL
 
     with pytest.raises(ValueError) as exc:
-        _where_unary_helper(None, 0, op_string=">")
+        unary_helper_function(None, 0, op_string=">")
     assert str(exc.value) == _BAD_OP_NAN_NULL
 
 

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -255,7 +255,6 @@ def _where_unary_helper(value, op_enum, op_string="=="):
     query_inst = _make_base_query_all_fields(skip_fields=("field_filters",))
     field_path = "feeeld"
     new_query = query_inst.where(field_path, op_string, value)
-
     assert query_inst is not new_query
     assert isinstance(new_query, BaseQuery)
     assert len(new_query._field_filters) == 1
@@ -263,6 +262,28 @@ def _where_unary_helper(value, op_enum, op_string="=="):
     field_pb = new_query._field_filters[0]
     expected_pb = StructuredQuery.UnaryFilter(
         field=StructuredQuery.FieldReference(field_path=field_path), op=op_enum
+    )
+    assert field_pb == expected_pb
+    _compare_queries(query_inst, new_query, "_field_filters")
+
+
+def _where_unary_helper_field_filter(value, op_enum, op_string="=="):
+    from google.cloud.firestore_v1.base_query import BaseQuery, FieldFilter
+    from google.cloud.firestore_v1.types import StructuredQuery
+
+    query_inst = _make_base_query_all_fields(skip_fields=("field_filters",))
+    field_path = "feeeld"
+
+    filter = FieldFilter(field_path, op_string, value)
+    new_query = query_inst.where(filter=filter)
+
+    assert query_inst is not new_query
+    assert isinstance(new_query, BaseQuery)
+    assert len(new_query._field_filters) == 1
+
+    field_pb = new_query._field_filters[0]
+    expected_pb = StructuredQuery.UnaryFilter(
+        field=StructuredQuery.FieldReference(field_path=filter.field_path), op=op_enum
     )
     assert field_pb == expected_pb
     _compare_queries(query_inst, new_query, "_field_filters")
@@ -276,48 +297,118 @@ def test_basequery_where_eq_null():
 
 
 def test_basequery_where_gt_null():
-    with pytest.raises(ValueError):
+    from google.cloud.firestore_v1.base_query import _BAD_OP_NAN_NULL
+
+    with pytest.raises(ValueError) as exc:
         _where_unary_helper(None, 0, op_string=">")
+    assert str(exc.value) == _BAD_OP_NAN_NULL
 
 
-def test_basequery_where_eq_nan():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_eq_nan(unary_helper_function):
     from google.cloud.firestore_v1.types import StructuredQuery
 
     op_enum = StructuredQuery.UnaryFilter.Operator.IS_NAN
-    _where_unary_helper(float("nan"), op_enum)
+    unary_helper_function(float("nan"), op_enum)
 
 
-def test_basequery_where_le_nan():
-    with pytest.raises(ValueError):
-        _where_unary_helper(float("nan"), 0, op_string="<=")
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_le_nan(unary_helper_function):
+    from google.cloud.firestore_v1.base_query import _BAD_OP_NAN_NULL
+
+    with pytest.raises(ValueError) as exc:
+        unary_helper_function(float("nan"), 0, op_string="<=")
+    assert str(exc.value) == _BAD_OP_NAN_NULL
 
 
-def test_basequery_where_w_delete():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_w_delete(unary_helper_function):
     from google.cloud.firestore_v1 import DELETE_FIELD
+    from google.cloud.firestore_v1.base_query import _INVALID_WHERE_TRANSFORM
 
-    with pytest.raises(ValueError):
-        _where_unary_helper(DELETE_FIELD, 0)
+    with pytest.raises(ValueError) as exc:
+        unary_helper_function(DELETE_FIELD, 0)
+    assert str(exc.value) == _INVALID_WHERE_TRANSFORM
 
 
-def test_basequery_where_w_server_timestamp():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_w_server_timestamp(unary_helper_function):
     from google.cloud.firestore_v1 import SERVER_TIMESTAMP
+    from google.cloud.firestore_v1.base_query import _INVALID_WHERE_TRANSFORM
 
-    with pytest.raises(ValueError):
-        _where_unary_helper(SERVER_TIMESTAMP, 0)
+    with pytest.raises(ValueError) as exc:
+        unary_helper_function(SERVER_TIMESTAMP, 0)
+    assert str(exc.value) == _INVALID_WHERE_TRANSFORM
 
 
-def test_basequery_where_w_array_remove():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_w_array_remove(unary_helper_function):
     from google.cloud.firestore_v1 import ArrayRemove
+    from google.cloud.firestore_v1.base_query import _INVALID_WHERE_TRANSFORM
 
-    with pytest.raises(ValueError):
-        _where_unary_helper(ArrayRemove([1, 3, 5]), 0)
+    with pytest.raises(ValueError) as exc:
+        unary_helper_function(ArrayRemove([1, 3, 5]), 0)
+    assert str(exc.value) == _INVALID_WHERE_TRANSFORM
 
 
-def test_basequery_where_w_array_union():
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_w_array_union(unary_helper_function):
     from google.cloud.firestore_v1 import ArrayUnion
+    from google.cloud.firestore_v1.base_query import _INVALID_WHERE_TRANSFORM
 
-    with pytest.raises(ValueError):
-        _where_unary_helper(ArrayUnion([2, 4, 8]), 0)
+    with pytest.raises(ValueError) as exc:
+        unary_helper_function(ArrayUnion([2, 4, 8]), 0)
+    assert str(exc.value) == _INVALID_WHERE_TRANSFORM
+
+
+@pytest.mark.parametrize(
+    "unary_helper_function",
+    [
+        (_where_unary_helper),
+        (_where_unary_helper_field_filter),
+    ],
+)
+def test_basequery_where_filter_eq_null(unary_helper_function):
+    from google.cloud.firestore_v1.types import StructuredQuery
+
+    op_enum = StructuredQuery.UnaryFilter.Operator.IS_NULL
+    unary_helper_function(None, op_enum)
 
 
 def test_basequery_order_by_invalid_path():
@@ -652,6 +743,288 @@ def test_basequery_end_at():
     assert isinstance(query5, BaseQuery)
     assert query5._end_at == (document_fields5, False)
     _compare_queries(query4, query5, "_end_at")
+
+
+def test_basequery_where_filter_keyword_arg():
+
+    from google.cloud.firestore_v1.types import StructuredQuery
+    from google.cloud.firestore_v1.types import document
+    from google.cloud.firestore_v1.types import query
+    from google.cloud.firestore_v1.base_query import FieldFilter, And, Or
+
+    op_class = StructuredQuery.FieldFilter.Operator
+
+    field_path_1 = "x.y"
+    op_str_1 = ">"
+    value_1 = 50.5
+
+    field_path_2 = "population"
+    op_str_2 = "=="
+    value_2 = 60000
+
+    field_filter_1 = FieldFilter(field_path_1, op_str_1, value_1)
+    field_filter_2 = FieldFilter(field_path_2, op_str_2, value_2)
+
+    q = _make_base_query(mock.sentinel.parent)
+    q = q.where(filter=field_filter_1)
+
+    filter_pb = q._filters_pb()
+    expected_pb = query.StructuredQuery.Filter(
+        field_filter=query.StructuredQuery.FieldFilter(
+            field=query.StructuredQuery.FieldReference(field_path=field_path_1),
+            op=StructuredQuery.FieldFilter.Operator.GREATER_THAN,
+            value=document.Value(double_value=value_1),
+        )
+    )
+    assert filter_pb == expected_pb
+
+    or_filter = Or(filters=[field_filter_1, field_filter_2])
+    q = _make_base_query(mock.sentinel.parent)
+    q = q.where(filter=or_filter)
+
+    filter_pb = q._filters_pb()
+    expected_pb = query.StructuredQuery.Filter(
+        query.StructuredQuery.Filter(
+            composite_filter=query.StructuredQuery.CompositeFilter(
+                op=StructuredQuery.CompositeFilter.Operator.OR,
+                filters=[
+                    query.StructuredQuery.Filter(
+                        field_filter=query.StructuredQuery.FieldFilter(
+                            field=query.StructuredQuery.FieldReference(
+                                field_path=field_path_1
+                            ),
+                            op=op_class.GREATER_THAN,
+                            value=document.Value(double_value=value_1),
+                        )
+                    ),
+                    query.StructuredQuery.Filter(
+                        field_filter=query.StructuredQuery.FieldFilter(
+                            field=query.StructuredQuery.FieldReference(
+                                field_path=field_path_2
+                            ),
+                            op=op_class.EQUAL,
+                            value=document.Value(integer_value=value_2),
+                        )
+                    ),
+                ],
+            )
+        )
+    )
+    assert filter_pb == expected_pb
+
+    and_filter = And(filters=[field_filter_1, field_filter_2])
+    q = _make_base_query(mock.sentinel.parent)
+    q = q.where(filter=and_filter)
+
+    filter_pb = q._filters_pb()
+    expected_pb = query.StructuredQuery.Filter(
+        query.StructuredQuery.Filter(
+            composite_filter=query.StructuredQuery.CompositeFilter(
+                op=StructuredQuery.CompositeFilter.Operator.AND,
+                filters=[
+                    query.StructuredQuery.Filter(
+                        field_filter=query.StructuredQuery.FieldFilter(
+                            field=query.StructuredQuery.FieldReference(
+                                field_path=field_path_1
+                            ),
+                            op=op_class.GREATER_THAN,
+                            value=document.Value(double_value=value_1),
+                        )
+                    ),
+                    query.StructuredQuery.Filter(
+                        field_filter=query.StructuredQuery.FieldFilter(
+                            field=query.StructuredQuery.FieldReference(
+                                field_path=field_path_2
+                            ),
+                            op=op_class.EQUAL,
+                            value=document.Value(integer_value=value_2),
+                        )
+                    ),
+                ],
+            )
+        )
+    )
+    assert filter_pb == expected_pb
+
+
+def test_basequery_where_cannot_pass_both_positional_and_keyword_filter_arg():
+
+    from google.cloud.firestore_v1.base_query import FieldFilter
+
+    field_path_1 = "x.y"
+    op_str_1 = ">"
+    value_1 = 50.5
+    filter = FieldFilter(field_path_1, op_str_1, value_1)
+    q = _make_base_query(mock.sentinel.parent)
+
+    with pytest.raises(
+        ValueError,
+        match="Can't pass in both the positional arguments and 'filter' at the same time",
+    ):
+        q.where(field_path_1, op_str_1, value_1, filter=filter)
+
+
+def test_basequery_where_cannot_pass_filter_without_keyword_arg():
+    from google.cloud.firestore_v1.base_query import FieldFilter, And
+
+    field_path_1 = "x.y"
+    op_str_1 = ">"
+    value_1 = 50.5
+    filter = FieldFilter(field_path_1, op_str_1, value_1)
+    q = _make_base_query(mock.sentinel.parent)
+
+    with pytest.raises(
+        ValueError,
+        match="FieldFilter object must be passed using keyword argument 'filter'",
+    ):
+        q.where(filter)
+
+    and_filter = And(filters=[filter])
+    with pytest.raises(
+        ValueError,
+        match="'Or' and 'And' objects must be passed using keyword argument 'filter'",
+    ):
+        q.where(and_filter)
+
+
+def test_basequery_where_mix_of_field_and_composite():
+    from google.cloud.firestore_v1.base_query import FieldFilter, And, Or
+    from google.cloud.firestore_v1.types import query
+    from google.cloud.firestore_v1.types.query import StructuredQuery
+    from google.cloud.firestore_v1.types import document
+
+    op_class = StructuredQuery.FieldFilter.Operator
+
+    field_path_1 = "x.y"
+    op_str_1 = ">"
+    value_1 = 50.5
+    filter_1 = FieldFilter(field_path_1, op_str_1, value_1)
+
+    field_path_2 = "population"
+    op_str_2 = "=="
+    value_2 = 60000
+    filter_2 = FieldFilter(field_path_2, op_str_2, value_2)
+
+    field_path_3 = "country"
+    op_str_3 = "=="
+    value_3 = "USA"
+    filter_3 = FieldFilter(field_path_3, op_str_3, value_3)
+
+    or_filter = Or(filters=[filter_2, filter_3])
+    combined_filter = And(filters=[filter_1, or_filter])
+    q = _make_base_query(mock.sentinel.parent)
+    q = q.where(filter=filter_1).where(filter=combined_filter)
+
+    filter_pb = q._filters_pb()
+
+    expected_pb = query.StructuredQuery.Filter(
+        composite_filter=query.StructuredQuery.CompositeFilter(
+            op=StructuredQuery.CompositeFilter.Operator.AND,
+            filters=[
+                query.StructuredQuery.Filter(
+                    field_filter=query.StructuredQuery.FieldFilter(
+                        field=query.StructuredQuery.FieldReference(
+                            field_path=field_path_1
+                        ),
+                        op=op_class.GREATER_THAN,
+                        value=document.Value(double_value=value_1),
+                    )
+                ),
+                query.StructuredQuery.Filter(
+                    composite_filter=query.StructuredQuery.CompositeFilter(
+                        op=StructuredQuery.CompositeFilter.Operator.AND,
+                        filters=[
+                            query.StructuredQuery.Filter(
+                                field_filter=query.StructuredQuery.FieldFilter(
+                                    field=query.StructuredQuery.FieldReference(
+                                        field_path=field_path_1
+                                    ),
+                                    op=op_class.GREATER_THAN,
+                                    value=document.Value(double_value=value_1),
+                                )
+                            ),
+                            query.StructuredQuery.Filter(
+                                composite_filter=query.StructuredQuery.CompositeFilter(
+                                    op=StructuredQuery.CompositeFilter.Operator.OR,
+                                    filters=[
+                                        query.StructuredQuery.Filter(
+                                            field_filter=query.StructuredQuery.FieldFilter(
+                                                field=query.StructuredQuery.FieldReference(
+                                                    field_path=field_path_2
+                                                ),
+                                                op=op_class.EQUAL,
+                                                value=document.Value(
+                                                    integer_value=value_2
+                                                ),
+                                            )
+                                        ),
+                                        query.StructuredQuery.Filter(
+                                            field_filter=query.StructuredQuery.FieldFilter(
+                                                field=query.StructuredQuery.FieldReference(
+                                                    field_path=field_path_3
+                                                ),
+                                                op=op_class.EQUAL,
+                                                value=document.Value(
+                                                    string_value=value_3
+                                                ),
+                                            )
+                                        ),
+                                    ],
+                                )
+                            ),
+                        ],
+                    )
+                ),
+            ],
+        )
+    )
+
+    assert filter_pb == expected_pb
+
+
+def test_basequery_where_filter_as_positional_arg():
+    from google.cloud.firestore_v1.base_query import FieldFilter, Or
+
+    field_path_1 = "x.y"
+    op_str_1 = ">"
+    value_1 = 50.5
+    filter_1 = FieldFilter(field_path_1, op_str_1, value_1)
+
+    q = _make_base_query(mock.sentinel.parent)
+    with pytest.raises(ValueError) as exc:
+        q.where(filter_1)
+    assert (
+        str(exc.value)
+        == "FieldFilter object must be passed using keyword argument 'filter'"
+    )
+
+    or_filter = Or(filters=[filter_1])
+    with pytest.raises(ValueError) as exc:
+        q.where(or_filter)
+    assert (
+        str(exc.value)
+        == "'Or' and 'And' objects must be passed using keyword argument 'filter'"
+    )
+
+
+def test_basequery_where_requires_a_filter():
+    q = _make_base_query(mock.sentinel.parent)
+
+    with pytest.raises(
+        ValueError,
+        match="Filter must be provided through positional arguments or the 'filter' keyword argument.",
+    ):
+        q.where()
+
+
+def test_query_add_filter_with_positional_args_raises_user_warning():
+    q = _make_base_query(mock.sentinel.parent)
+
+    with pytest.warns(
+        UserWarning,
+        match="Detected filter using positional arguments",
+    ):
+        q.where("x.y", "==", 50)
 
 
 def test_basequery__filters_pb_empty():
@@ -1623,6 +1996,18 @@ def test_query_end():
     assert query.orders == "ORDER"
     assert query.start_at == (["start"], True)
     assert query.end_at is None
+
+
+def test_base_composite_filter_constructor():
+    from google.cloud.firestore_v1.base_query import BaseCompositeFilter
+    from google.cloud.firestore_v1.types import query
+
+    comp_filter = BaseCompositeFilter()
+    assert (
+        comp_filter.operator
+        == query.StructuredQuery.CompositeFilter.Operator.OPERATOR_UNSPECIFIED
+    )
+    assert len(comp_filter.filters) == 0
 
 
 class DummyQuery:


### PR DESCRIPTION
Introduce new Filter classes:

FieldFilter
And
Or

Add `filter` keyword arg to `Query.where()`
The positional arguments in `Query.where()` are now optional. `UserWarning` is now emitted when using `where()` without keyword args.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
