### PR TITLE
fix: expose Count, FieldFilter, Or, and And to firestore module

### DIFF
--- a/google/cloud/firestore/__init__.py
+++ b/google/cloud/firestore/__init__.py
@@ -19,6 +19,7 @@ from google.cloud.firestore_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
 
+from google.cloud.firestore_v1 import And
 from google.cloud.firestore_v1 import ArrayRemove
 from google.cloud.firestore_v1 import ArrayUnion
 from google.cloud.firestore_v1 import AsyncClient
@@ -28,6 +29,7 @@ from google.cloud.firestore_v1 import AsyncQuery
 from google.cloud.firestore_v1 import async_transactional
 from google.cloud.firestore_v1 import AsyncTransaction
 from google.cloud.firestore_v1 import AsyncWriteBatch
+from google.cloud.firestore_v1 import CountAggregation
 from google.cloud.firestore_v1 import Client
 from google.cloud.firestore_v1 import CollectionGroup
 from google.cloud.firestore_v1 import CollectionReference
@@ -36,11 +38,13 @@ from google.cloud.firestore_v1 import DocumentReference
 from google.cloud.firestore_v1 import DocumentSnapshot
 from google.cloud.firestore_v1 import DocumentTransform
 from google.cloud.firestore_v1 import ExistsOption
+from google.cloud.firestore_v1 import FieldFilter
 from google.cloud.firestore_v1 import GeoPoint
 from google.cloud.firestore_v1 import Increment
 from google.cloud.firestore_v1 import LastUpdateOption
 from google.cloud.firestore_v1 import Maximum
 from google.cloud.firestore_v1 import Minimum
+from google.cloud.firestore_v1 import Or
 from google.cloud.firestore_v1 import Query
 from google.cloud.firestore_v1 import ReadAfterWriteError
 from google.cloud.firestore_v1 import SERVER_TIMESTAMP
@@ -55,6 +59,7 @@ from typing import List
 
 __all__: List[str] = [
     "__version__",
+    "And",
     "ArrayRemove",
     "ArrayUnion",
     "AsyncClient",
@@ -67,16 +72,19 @@ __all__: List[str] = [
     "Client",
     "CollectionGroup",
     "CollectionReference",
+    "CountAggregation",
     "DELETE_FIELD",
     "DocumentReference",
     "DocumentSnapshot",
     "DocumentTransform",
     "ExistsOption",
+    "FieldFilter",
     "GeoPoint",
     "Increment",
     "LastUpdateOption",
     "Maximum",
     "Minimum",
+    "Or",
     "Query",
     "ReadAfterWriteError",
     "SERVER_TIMESTAMP",

--- a/google/cloud/firestore/__init__.py
+++ b/google/cloud/firestore/__init__.py
@@ -29,8 +29,8 @@ from google.cloud.firestore_v1 import AsyncQuery
 from google.cloud.firestore_v1 import async_transactional
 from google.cloud.firestore_v1 import AsyncTransaction
 from google.cloud.firestore_v1 import AsyncWriteBatch
-from google.cloud.firestore_v1 import CountAggregation
 from google.cloud.firestore_v1 import Client
+from google.cloud.firestore_v1 import CountAggregation
 from google.cloud.firestore_v1 import CollectionGroup
 from google.cloud.firestore_v1 import CollectionReference
 from google.cloud.firestore_v1 import DELETE_FIELD
@@ -70,9 +70,9 @@ __all__: List[str] = [
     "AsyncTransaction",
     "AsyncWriteBatch",
     "Client",
+    "CountAggregation",
     "CollectionGroup",
     "CollectionReference",
-    "CountAggregation",
     "DELETE_FIELD",
     "DocumentReference",
     "DocumentSnapshot",

--- a/google/cloud/firestore_v1/__init__.py
+++ b/google/cloud/firestore_v1/__init__.py
@@ -29,6 +29,10 @@ from google.cloud.firestore_v1._helpers import ExistsOption
 from google.cloud.firestore_v1._helpers import LastUpdateOption
 from google.cloud.firestore_v1._helpers import ReadAfterWriteError
 from google.cloud.firestore_v1._helpers import WriteOption
+from google.cloud.firestore_v1.base_aggregation import CountAggregation
+from google.cloud.firestore_v1.base_query import And
+from google.cloud.firestore_v1.base_query import FieldFilter
+from google.cloud.firestore_v1.base_query import Or
 from google.cloud.firestore_v1.async_batch import AsyncWriteBatch
 from google.cloud.firestore_v1.async_client import AsyncClient
 from google.cloud.firestore_v1.async_collection import AsyncCollectionReference
@@ -107,6 +111,7 @@ from typing import List
 
 __all__: List[str] = [
     "__version__",
+    "And",
     "ArrayRemove",
     "ArrayUnion",
     "AsyncClient",
@@ -117,6 +122,7 @@ __all__: List[str] = [
     "AsyncTransaction",
     "AsyncWriteBatch",
     "Client",
+    "CountAggregation",
     "CollectionGroup",
     "CollectionReference",
     "DELETE_FIELD",
@@ -124,11 +130,13 @@ __all__: List[str] = [
     "DocumentSnapshot",
     "DocumentTransform",
     "ExistsOption",
+    "FieldFilter",
     "GeoPoint",
     "Increment",
     "LastUpdateOption",
     "Maximum",
     "Minimum",
+    "Or",
     "Query",
     "ReadAfterWriteError",
     "SERVER_TIMESTAMP",


### PR DESCRIPTION
Expose the `Count`, `FieldFilter`, `Or`, and `And` to the `firestore` module from the `firestore_v1`.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #704  🦕
