### PR TITLE
chore: update required test version

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -17,7 +17,7 @@ branchProtectionRules:
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro system-3.8'
+    - 'Kokoro system-3.7'
     - 'cla/google'
     - 'OwlBot Post Processor'
     - 'docs'


### PR DESCRIPTION
the sync-repo-settings file required system-3.8, but this repo still uses system-3.7. This PR fixes the required check to match