### PR TITLE
fix: extract nested list fields

### DIFF
--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -450,6 +450,9 @@ def extract_fields(
             if isinstance(value, dict):
                 for s_path, s_value in extract_fields(value, field_path):
                     yield s_path, s_value
+            elif isinstance(value, (list, tuple, set, frozenset)):
+                for s_value in value:
+                    yield field_path, s_value
             else:
                 yield field_path, value
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -223,7 +223,7 @@ def test_document_set_w_nested_list(client, cleanup, database):
     assert snapshot.to_dict() is None
 
     # 1. Use ``create()`` to create the document.
-    data1 = {"a": {"x": 1, "y":2}}
+    data1 = {"a": {"x": 1, "y": 2}}
     write_result1 = document.create(data1)
     snapshot1 = document.get()
     assert snapshot1.to_dict() == data1
@@ -232,7 +232,7 @@ def test_document_set_w_nested_list(client, cleanup, database):
     assert snapshot1.update_time == write_result1.update_time
 
     # 2. Call ``set()`` again to delete sub-field
-    data2 = {"a": {"x":firestore.DELETE_FIELD}}
+    data2 = {"a": {"x": firestore.DELETE_FIELD}}
     write_result2 = document.set(data2, merge=True)
     snapshot2 = document.get()
     assert snapshot2.to_dict() == {"a": {"y": 2}}


### PR DESCRIPTION
When running `set` with a list of fields, the list wasn't being iterated properly, leading to potential crashes.

This PR resolves the issue by properly iterating over lists in `extract_fields`

Fixes https://github.com/googleapis/python-firestore/issues/665