### PR TITLE
fix: order normalization with descending query

### DIFF
--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -91,7 +91,7 @@ _EQUALITY_OPERATORS = (
     _operator_enum.EQUAL,
     _operator_enum.ARRAY_CONTAINS,
     _operator_enum.ARRAY_CONTAINS_ANY,
-    _operator_enum.IN
+    _operator_enum.IN,
 )
 _BAD_OP_STRING = "Operator string {!r} is invalid. Valid choices are: {}."
 _BAD_OP_NAN_NULL = 'Only an equality filter ("==") can be used with None or NaN values'
@@ -876,7 +876,10 @@ class BaseQuery(object):
                 if isinstance(filter_.op, StructuredQuery.FieldFilter.Operator):
                     field = filter_.field.field_path
                     # skip equality filters and filters on fields already ordered
-                    if filter_.op not in _EQUALITY_OPERATORS and field not in order_keys:
+                    if (
+                        filter_.op not in _EQUALITY_OPERATORS
+                        and field not in order_keys
+                    ):
                         orders.append(self._make_order(field, direction))
             # add __name__ if not already in orders
             if "__name__" not in [order.field.field_path for order in orders]:

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -868,7 +868,7 @@ class BaseQuery(object):
                 _has_snapshot_cursor = True
         if _has_snapshot_cursor:
             # added orders should use direction of last order
-            direction = orders[-1].direction if orders else BaseQuery.ASCENDING
+            last_direction = orders[-1].direction if orders else BaseQuery.ASCENDING
             order_keys = [order.field.field_path for order in orders]
             for filter_ in self._field_filters:
                 # FieldFilter.Operator should not compare equal to
@@ -880,10 +880,10 @@ class BaseQuery(object):
                         filter_.op not in _EQUALITY_OPERATORS
                         and field not in order_keys
                     ):
-                        orders.append(self._make_order(field, direction))
+                        orders.append(self._make_order(field, last_direction))
             # add __name__ if not already in orders
             if "__name__" not in [order.field.field_path for order in orders]:
-                orders.append(self._make_order("__name__", direction))
+                orders.append(self._make_order("__name__", last_direction))
 
         return orders
 

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -85,6 +85,8 @@ _COMPARISON_OPERATORS = {
     "not-in": _operator_enum.NOT_IN,
     "array_contains_any": _operator_enum.ARRAY_CONTAINS_ANY,
 }
+_NO_ORDER_OPERATORS = (_operator_enum.EQUAL, _operator_enum.ARRAY_CONTAINS)
+_SHOULD_ORDER_OPERATORS = [val for val in _COMPARISON_OPERATORS.values() if val not in _NO_ORDER_OPERATORS]
 _BAD_OP_STRING = "Operator string {!r} is invalid. Valid choices are: {}."
 _BAD_OP_NAN_NULL = 'Only an equality filter ("==") can be used with None or NaN values'
 _INVALID_WHERE_TRANSFORM = "Transforms cannot be used as where values."
@@ -858,20 +860,14 @@ class BaseQuery(object):
         if self._end_at:
             if isinstance(self._end_at[0], document.DocumentSnapshot):
                 _has_snapshot_cursor = True
-
         if _has_snapshot_cursor:
-            should_order = [
-                _enum_from_op_string(key)
-                for key in _COMPARISON_OPERATORS
-                if key not in (_EQ_OP, "array_contains")
-            ]
             order_keys = [order.field.field_path for order in orders]
             for filter_ in self._field_filters:
                 # FieldFilter.Operator should not compare equal to
                 # UnaryFilter.Operator, but it does
                 if isinstance(filter_.op, StructuredQuery.FieldFilter.Operator):
                     field = filter_.field.field_path
-                    if filter_.op in should_order and field not in order_keys:
+                    if filter_.op in _SHOULD_ORDER_OPERATORS and field not in order_keys:
                         orders.append(self._make_order(field, "ASCENDING"))
             if not orders:
                 orders.append(self._make_order("__name__", "ASCENDING"))

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -878,10 +878,7 @@ class BaseQuery(object):
                 if isinstance(filter_.op, StructuredQuery.FieldFilter.Operator):
                     field = filter_.field.field_path
                     # skip equality filters and filters on fields already ordered
-                    if (
-                        filter_.op in _INEQUALITY_OPERATORS
-                        and field not in order_keys
-                    ):
+                    if filter_.op in _INEQUALITY_OPERATORS and field not in order_keys:
                         orders.append(self._make_order(field, last_direction))
             # add __name__ if not already in orders
             if "__name__" not in [order.field.field_path for order in orders]:

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -868,7 +868,7 @@ class BaseQuery(object):
                 _has_snapshot_cursor = True
         if _has_snapshot_cursor:
             # added orders should use direction of last order
-            direction = orders[-1].direction if orders else "ASCENDING"  # enum?
+            direction = orders[-1].direction if orders else BaseQuery.ASCENDING
             order_keys = [order.field.field_path for order in orders]
             for filter_ in self._field_filters:
                 # FieldFilter.Operator should not compare equal to

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -86,7 +86,7 @@ _COMPARISON_OPERATORS = {
     "array_contains_any": _operator_enum.ARRAY_CONTAINS_ANY,
 }
 # set of operators that involve equlity comparisons
-# should  be skipped when normalizing query
+# should be skipped when normalizing query
 _EQUALITY_OPERATORS = (
     _operator_enum.EQUAL,
     _operator_enum.ARRAY_CONTAINS,

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -85,13 +85,15 @@ _COMPARISON_OPERATORS = {
     "not-in": _operator_enum.NOT_IN,
     "array_contains_any": _operator_enum.ARRAY_CONTAINS_ANY,
 }
-# set of operators that involve equlity comparisons
-# should be skipped when normalizing query
-_EQUALITY_OPERATORS = (
-    _operator_enum.EQUAL,
-    _operator_enum.ARRAY_CONTAINS,
-    _operator_enum.ARRAY_CONTAINS_ANY,
-    _operator_enum.IN,
+# set of operators that don't involve equlity comparisons
+# will be used in query normalization
+_INEQUALITY_OPERATORS = (
+    _operator_enum.LESS_THAN,
+    _operator_enum.LESS_THAN_OR_EQUAL,
+    _operator_enum.GREATER_THAN_OR_EQUAL,
+    _operator_enum.GREATER_THAN,
+    _operator_enum.NOT_EQUAL,
+    _operator_enum.NOT_IN,
 )
 _BAD_OP_STRING = "Operator string {!r} is invalid. Valid choices are: {}."
 _BAD_OP_NAN_NULL = 'Only an equality filter ("==") can be used with None or NaN values'
@@ -877,7 +879,7 @@ class BaseQuery(object):
                     field = filter_.field.field_path
                     # skip equality filters and filters on fields already ordered
                     if (
-                        filter_.op not in _EQUALITY_OPERATORS
+                        filter_.op in _INEQUALITY_OPERATORS
                         and field not in order_keys
                     ):
                         orders.append(self._make_order(field, last_direction))

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -1206,17 +1206,21 @@ def test_basequery__normalize_orders_w_name_orders_w_none_cursor():
     expected = [query._make_order("__name__", "DESCENDING")]
     assert query._normalize_orders() == expected
 
+
 def test_basequery__normalize_orders_w_cursor_descending():
     """
     Test case for b/306472103
     """
     from google.cloud.firestore_v1.base_query import FieldFilter
+
     collection = _make_collection("here")
     snapshot = _make_snapshot(_make_docref("here", "doc_id"), {"a": 1, "b": 2})
-    query = _make_base_query(collection) \
-        .where(filter=FieldFilter("a", "==", 1)) \
-        .where(filter=FieldFilter("b", "in", [1, 2, 3])) \
+    query = (
+        _make_base_query(collection)
+        .where(filter=FieldFilter("a", "==", 1))
+        .where(filter=FieldFilter("b", "in", [1, 2, 3]))
         .order_by("c", "DESCENDING")
+    )
     query_w_snapshot = query.start_after(snapshot)
 
     normalized = query._normalize_orders()
@@ -1227,18 +1231,22 @@ def test_basequery__normalize_orders_w_cursor_descending():
     expected_w_snapshot = expected + [query._make_order("__name__", "DESCENDING")]
     assert normalized_w_snapshot == expected_w_snapshot
 
+
 def test_basequery__normalize_orders_w_cursor_descending_w_inequality():
     """
     Test case for b/306472103, with extra ineuality filter in "where" clause
     """
     from google.cloud.firestore_v1.base_query import FieldFilter
+
     collection = _make_collection("here")
     snapshot = _make_snapshot(_make_docref("here", "doc_id"), {"a": 1, "b": 2})
-    query = _make_base_query(collection) \
-        .where(filter=FieldFilter("a", "==", 1)) \
-        .where(filter=FieldFilter("b", "in", [1, 2, 3])) \
-        .where(filter=FieldFilter("b", "not-in", [4, 5, 6])) \
+    query = (
+        _make_base_query(collection)
+        .where(filter=FieldFilter("a", "==", 1))
+        .where(filter=FieldFilter("b", "in", [1, 2, 3]))
+        .where(filter=FieldFilter("b", "not-in", [4, 5, 6]))
         .order_by("c", "DESCENDING")
+    )
     query_w_snapshot = query.start_after(snapshot)
 
     normalized = query._normalize_orders()
@@ -1248,9 +1256,10 @@ def test_basequery__normalize_orders_w_cursor_descending_w_inequality():
     normalized_w_snapshot = query_w_snapshot._normalize_orders()
     expected_w_snapshot = expected + [
         query._make_order("b", "DESCENDING"),
-        query._make_order("__name__", "DESCENDING")
+        query._make_order("__name__", "DESCENDING"),
     ]
     assert normalized_w_snapshot == expected_w_snapshot
+
 
 def test_basequery__normalize_cursor_none():
     query = _make_base_query(mock.sentinel.parent)

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -1206,6 +1206,51 @@ def test_basequery__normalize_orders_w_name_orders_w_none_cursor():
     expected = [query._make_order("__name__", "DESCENDING")]
     assert query._normalize_orders() == expected
 
+def test_basequery__normalize_orders_w_cursor_descending():
+    """
+    Test case for b/306472103
+    """
+    from google.cloud.firestore_v1.base_query import FieldFilter
+    collection = _make_collection("here")
+    snapshot = _make_snapshot(_make_docref("here", "doc_id"), {"a": 1, "b": 2})
+    query = _make_base_query(collection) \
+        .where(filter=FieldFilter("a", "==", 1)) \
+        .where(filter=FieldFilter("b", "in", [1, 2, 3])) \
+        .order_by("c", "DESCENDING")
+    query_w_snapshot = query.start_after(snapshot)
+
+    normalized = query._normalize_orders()
+    expected = [query._make_order("c", "DESCENDING")]
+    assert normalized == expected
+
+    normalized_w_snapshot = query_w_snapshot._normalize_orders()
+    expected_w_snapshot = expected + [query._make_order("__name__", "DESCENDING")]
+    assert normalized_w_snapshot == expected_w_snapshot
+
+def test_basequery__normalize_orders_w_cursor_descending_w_inequality():
+    """
+    Test case for b/306472103, with extra ineuality filter in "where" clause
+    """
+    from google.cloud.firestore_v1.base_query import FieldFilter
+    collection = _make_collection("here")
+    snapshot = _make_snapshot(_make_docref("here", "doc_id"), {"a": 1, "b": 2})
+    query = _make_base_query(collection) \
+        .where(filter=FieldFilter("a", "==", 1)) \
+        .where(filter=FieldFilter("b", "in", [1, 2, 3])) \
+        .where(filter=FieldFilter("b", "not-in", [4, 5, 6])) \
+        .order_by("c", "DESCENDING")
+    query_w_snapshot = query.start_after(snapshot)
+
+    normalized = query._normalize_orders()
+    expected = [query._make_order("c", "DESCENDING")]
+    assert normalized == expected
+
+    normalized_w_snapshot = query_w_snapshot._normalize_orders()
+    expected_w_snapshot = expected + [
+        query._make_order("b", "DESCENDING"),
+        query._make_order("__name__", "DESCENDING")
+    ]
+    assert normalized_w_snapshot == expected_w_snapshot
 
 def test_basequery__normalize_cursor_none():
     query = _make_base_query(mock.sentinel.parent)

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -1244,18 +1244,19 @@ def test_basequery__normalize_orders_w_cursor_descending_w_inequality():
         _make_base_query(collection)
         .where(filter=FieldFilter("a", "==", 1))
         .where(filter=FieldFilter("b", "in", [1, 2, 3]))
-        .where(filter=FieldFilter("b", "not-in", [4, 5, 6]))
-        .order_by("c", "DESCENDING")
+        .where(filter=FieldFilter("c", "not-in", [4, 5, 6]))
+        .order_by("d", "DESCENDING")
     )
     query_w_snapshot = query.start_after(snapshot)
 
     normalized = query._normalize_orders()
-    expected = [query._make_order("c", "DESCENDING")]
+    expected = [query._make_order("d", "DESCENDING")]
     assert normalized == expected
 
     normalized_w_snapshot = query_w_snapshot._normalize_orders()
-    expected_w_snapshot = expected + [
-        query._make_order("b", "DESCENDING"),
+    expected_w_snapshot = [
+        query._make_order("d", "DESCENDING")
+        query._make_order("c", "DESCENDING"),
         query._make_order("__name__", "DESCENDING"),
     ]
     assert normalized_w_snapshot == expected_w_snapshot

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -1255,7 +1255,7 @@ def test_basequery__normalize_orders_w_cursor_descending_w_inequality():
 
     normalized_w_snapshot = query_w_snapshot._normalize_orders()
     expected_w_snapshot = [
-        query._make_order("d", "DESCENDING")
+        query._make_order("d", "DESCENDING"),
         query._make_order("c", "DESCENDING"),
         query._make_order("__name__", "DESCENDING"),
     ]


### PR DESCRIPTION
This PR fixes a bug in order normalization logic, to be more in line [with nodejs](https://github.com/googleapis/nodejs-firestore/blob/5da7138abc15e99edc51fdfd25a70bf5eb0c97b9/dev/src/reference.ts#L1972):

- all equality operators should be skipped when normalizing (previously, "in" and "array_contains_any" would still be added)
- always use the last direction when normalizing a query, instead of adding "ASCENDING" sections