### PR TITLE
feat: find emulator project id from environment variable

### DIFF
--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -132,7 +132,11 @@ class BaseClient(ClientWithProject):
                 credentials = AnonymousCredentials()
             if project is None:
                 # extract project from env var, or use system default
-                project = os.getenv("GCLOUD_PROJECT", _DEFAULT_EMULATOR_PROJECT)
+                project = (
+                    os.getenv("GOOGLE_CLOUD_PROJECT")
+                    or os.getenv("GCLOUD_PROJECT")
+                    or _DEFAULT_EMULATOR_PROJECT
+                )
 
         super(BaseClient, self).__init__(
             project=project,

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -131,7 +131,8 @@ class BaseClient(ClientWithProject):
             if credentials is None:
                 credentials = AnonymousCredentials()
             if project is None:
-                project = _DEFAULT_EMULATOR_PROJECT
+                # extract project from env var, or use system default
+                project = os.getenv("GCLOUD_PROJECT", _DEFAULT_EMULATOR_PROJECT)
 
         super(BaseClient, self).__init__(
             project=project,

--- a/tests/unit/v1/test_client.py
+++ b/tests/unit/v1/test_client.py
@@ -118,8 +118,6 @@ def test_client_constructor_emulator(extra_env, project_expected):
 
     If project is not set, should be detected from GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
     """
-    from google.cloud.firestore_v1.client import _CLIENT_INFO
-
     expected_host = "localhost:8080"
     environment = {"FIRESTORE_EMULATOR_HOST": expected_host}
     if extra_env:

--- a/tests/unit/v1/test_client.py
+++ b/tests/unit/v1/test_client.py
@@ -18,7 +18,10 @@ import types
 import mock
 import pytest
 
-from google.cloud.firestore_v1.base_client import DEFAULT_DATABASE
+from google.cloud.firestore_v1.base_client import (
+    DEFAULT_DATABASE,
+    _DEFAULT_EMULATOR_PROJECT,
+)
 
 PROJECT = "my-prahjekt"
 
@@ -98,6 +101,34 @@ def test_client_constructor_explicit(database, expected):
     assert client._database == expected
     assert client._client_info is client_info
     assert client._client_options is client_options
+
+
+@pytest.mark.parametrize(
+    "extra_env,project_expected",
+    [
+        ({}, _DEFAULT_EMULATOR_PROJECT),
+        ({"GCLOUD_PROJECT": "gcloud"}, "gcloud"),
+        ({"GOOGLE_CLOUD_PROJECT": "google"}, "google"),
+        ({"GCLOUD_PROJECT": "gcloud", "GOOGLE_CLOUD_PROJECT": "google"}, "google"),
+    ],
+)
+def test_client_constructor_emulator(extra_env, project_expected):
+    """
+    Ensure client can be configured with FIRESOTRE_EMULATOR_HOST environment variable
+
+    If project is not set, should be detected from GCLOUD_PROJECT or GOOGLE_CLOUD_PROJECT
+    """
+    from google.cloud.firestore_v1.client import _CLIENT_INFO
+
+    expected_host = "localhost:8080"
+    environment = {"FIRESTORE_EMULATOR_HOST": expected_host}
+    if extra_env:
+        environment.update(extra_env)
+
+    with mock.patch("os.environ", environment):
+        client = _make_client()
+        assert client._emulator_host == expected_host
+        assert client.project == project_expected
 
 
 @pytest.mark.parametrize("database", [None, DEFAULT_DATABASE, "somedb"])


### PR DESCRIPTION
Previously, if `FIRESTORE_EMULATOR_HOST` was set and a `Client` instance was created without an explicit project, it would fall-back to `google-cloud-firestore-emulator`

This change makes it check the `GCLOUD_PROJECT` variable for a project id first, which is used by the firebase functions emulator. This means the client will auto-detect the project id if not given in the emulator, just like in a live GCP environment

Fixes https://github.com/firebase/firebase-functions-python/issues/174


BEGIN_COMMIT_OVERRIDE
fix: find emulator project id from environment variable
END_COMMIT_OVERRIDE
