### PR TITLE
fix: add google-auth as a direct dependency

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,8 +12,8 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-firestore/pull/716 is merged
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning    
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning
-    # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
-    ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel
+    # Remove warning once https://github.com/grpc/grpc/issues/35974 is fixed
+    ignore:unclosed:ResourceWarning
     # Remove after support for Python 3.7 is dropped
     ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
     # Remove warning once https://github.com/googleapis/gapic-generator-python/issues/1939 is fixed

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ version = version["__version__"]
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.34.0, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    # Exclude incompatible versions of `google-auth`
+    # See https://github.com/googleapis/google-cloud-python/issues/12364
+    "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
     "google-cloud-core >= 1.4.1, <3.0.0dev",
     "proto-plus >= 1.22.0, <2.0.0dev",
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-api-core==1.34.0
+google-auth==2.14.1
 google-cloud-core==1.4.1
 proto-plus==1.22.0
 protobuf==3.19.5  # transitive from `google-api-core`


### PR DESCRIPTION
`google.auth` is used in this repository and should be added as a direct dependency so that the minimum version can be stated and tested
https://github.com/search?q=repo%3Agoogleapis%2Fpython-firestore%20google.auth&type=code

The `setup.py` from the [autogenerated code](https://github.com/googleapis/googleapis-gen/blob/1e60e0e39bd5fe144b72acd306327f35a55a6d82/google/firestore/v1/firestore-v1-py/setup.py#L45) is not used in this repository hence this PR to apply the changes manually.

https://github.com/googleapis/python-firestore/blob/3a572b5d92b7bb20232b0b271a457fc4b6572f0e/setup.py#L33-L39

