### PR TITLE
fix: save commit time and write results to transaction object

### DIFF
--- a/google/cloud/firestore_v1/async_transaction.py
+++ b/google/cloud/firestore_v1/async_transaction.py
@@ -142,7 +142,11 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         )
 
         self._clean_up()
-        return list(commit_response.write_results)
+
+        self.commit_time = commit_response.commit_time
+        self.write_results = results = list(commit_response.write_results)
+
+        return results
 
     async def get_all(
         self,

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -142,7 +142,11 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         )
 
         self._clean_up()
-        return list(commit_response.write_results)
+
+        self.commit_time = commit_response.commit_time
+        self.write_results = results = list(commit_response.write_results)
+
+        return results
 
     def get_all(
         self,


### PR DESCRIPTION
This fix allows using commit time and write results after running a transaction in a decorated transactional function.

Fixes #927 🦕
