### PR TITLE
chore(docs): update proto path references

### DIFF
--- a/google/cloud/firestore_v1/_helpers.py
+++ b/google/cloud/firestore_v1/_helpers.py
@@ -414,7 +414,7 @@ def get_doc_id(document_pb, expected_prefix) -> str:
     """Parse a document ID from a document protobuf.
 
     Args:
-        document_pb (google.cloud.proto.firestore.v1.\
+        document_pb (google.cloud.firestore_v1.\
             document.Document): A protobuf for a document that
             was created in a ``CreateDocument`` RPC.
         expected_prefix (str): The expected collection prefix for the

--- a/google/cloud/firestore_v1/async_batch.py
+++ b/google/cloud/firestore_v1/async_batch.py
@@ -50,7 +50,7 @@ class AsyncWriteBatch(BaseWriteBatch):
                 system-specified value.
 
         Returns:
-            List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:
+            List[:class:`google.cloud.firestore_v1.write.WriteResult`, ...]:
             The write results corresponding to the changes committed, returned
             in the same order as the changes were applied to this batch. A
             write result contains an ``update_time`` field.

--- a/google/cloud/firestore_v1/async_query.py
+++ b/google/cloud/firestore_v1/async_query.py
@@ -59,13 +59,13 @@ class AsyncQuery(BaseQuery):
     Args:
         parent (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
             The collection that this query applies to.
-        projection (Optional[:class:`google.cloud.proto.firestore.v1.\
+        projection (Optional[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.Projection`]):
             A projection of document fields to limit the query results to.
-        field_filters (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+        field_filters (Optional[Tuple[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.FieldFilter`, ...]]):
             The filters to be applied in the query.
-        orders (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+        orders (Optional[Tuple[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.Order`, ...]]):
             The "order by" entries to use in the query.
         limit (Optional[int]):

--- a/google/cloud/firestore_v1/async_transaction.py
+++ b/google/cloud/firestore_v1/async_transaction.py
@@ -63,7 +63,7 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         """Add `Write`` protobufs to this transaction.
 
         Args:
-            write_pbs (List[google.cloud.proto.firestore.v1.\
+            write_pbs (List[google.cloud.firestore_v1.\
                 write.Write]): A list of write protobufs to be added.
 
         Raises:
@@ -124,7 +124,7 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         """Transactionally commit the changes accumulated.
 
         Returns:
-            List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:
+            List[:class:`google.cloud.firestore_v1.write.WriteResult`, ...]:
             The write results corresponding to the changes committed, returned
             in the same order as the changes were applied to this transaction.
             A write result contains an ``update_time`` field.

--- a/google/cloud/firestore_v1/base_batch.py
+++ b/google/cloud/firestore_v1/base_batch.py
@@ -55,7 +55,7 @@ class BaseBatch(metaclass=abc.ABCMeta):
         This method intended to be over-ridden by subclasses.
 
         Args:
-            write_pbs (List[google.cloud.proto.firestore.v1.\
+            write_pbs (List[google.cloud.firestore_v1.\
                 write_pb2.Write]): A list of write protobufs to be added.
         """
         self._write_pbs.extend(write_pbs)

--- a/google/cloud/firestore_v1/base_client.py
+++ b/google/cloud/firestore_v1/base_client.py
@@ -537,7 +537,7 @@ def _parse_batch_get(
     """Parse a `BatchGetDocumentsResponse` protobuf.
 
     Args:
-        get_doc_response (~google.cloud.proto.firestore.v1.\
+        get_doc_response (~google.cloud.firestore_v1.\
             firestore.BatchGetDocumentsResponse): A single response (from
             a stream) containing the "get" response for a document.
         reference_map (Dict[str, .DocumentReference]): A mapping (produced

--- a/google/cloud/firestore_v1/base_document.py
+++ b/google/cloud/firestore_v1/base_document.py
@@ -548,7 +548,7 @@ def _consume_single_get(response_iterator) -> firestore.BatchGetDocumentsRespons
             request.
 
     Returns:
-        ~google.cloud.proto.firestore.v1.\
+        ~google.cloud.firestore_v1.\
             firestore.BatchGetDocumentsResponse: The single "get"
         response in the batch.
 
@@ -575,7 +575,7 @@ def _first_write_result(write_results: list) -> write.WriteResult:
     at the same time).
 
     Args:
-        write_results (List[google.cloud.proto.firestore.v1.\
+        write_results (List[google.cloud.firestore_v1.\
             write.WriteResult, ...]: The write results from a
             ``CommitResponse``.
 

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -236,13 +236,13 @@ class BaseQuery(object):
     Args:
         parent (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
             The collection that this query applies to.
-        projection (Optional[:class:`google.cloud.proto.firestore.v1.\
+        projection (Optional[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.Projection`]):
             A projection of document fields to limit the query results to.
-        field_filters (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+        field_filters (Optional[Tuple[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.FieldFilter`, ...]]):
             The filters to be applied in the query.
-        orders (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+        orders (Optional[Tuple[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.Order`, ...]]):
             The "order by" entries to use in the query.
         limit (Optional[int]):
@@ -1225,9 +1225,9 @@ def _filter_pb(field_or_unary) -> StructuredQuery.Filter:
     """Convert a specific protobuf filter to the generic filter type.
 
     Args:
-        field_or_unary (Union[google.cloud.proto.firestore.v1.\
-            query.StructuredQuery.FieldFilter, google.cloud.proto.\
-            firestore.v1.query.StructuredQuery.FieldFilter]): A
+        field_or_unary (Union[google.cloud.firestore_v1.\
+            query.StructuredQuery.FieldFilter, google.cloud.\
+            firestore_v1.query.StructuredQuery.FieldFilter]): A
             field or unary filter to convert to a generic filter.
 
     Returns:
@@ -1272,7 +1272,7 @@ def _query_response_to_snapshot(
     """Parse a query response protobuf to a document snapshot.
 
     Args:
-        response_pb (google.cloud.proto.firestore.v1.\
+        response_pb (google.cloud.firestore_v1.\
             firestore.RunQueryResponse): A
         collection (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
             A reference to the collection that initiated the query.
@@ -1308,7 +1308,7 @@ def _collection_group_query_response_to_snapshot(
     """Parse a query response protobuf to a document snapshot.
 
     Args:
-        response_pb (google.cloud.proto.firestore.v1.\
+        response_pb (google.cloud.firestore_v1.\
             firestore.RunQueryResponse): A
         collection (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
             A reference to the collection that initiated the query.

--- a/google/cloud/firestore_v1/batch.py
+++ b/google/cloud/firestore_v1/batch.py
@@ -49,7 +49,7 @@ class WriteBatch(BaseWriteBatch):
                 system-specified value.
 
         Returns:
-            List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:
+            List[:class:`google.cloud.firestore_v1.write.WriteResult`, ...]:
             The write results corresponding to the changes committed, returned
             in the same order as the changes were applied to this batch. A
             write result contains an ``update_time`` field.

--- a/google/cloud/firestore_v1/bulk_batch.py
+++ b/google/cloud/firestore_v1/bulk_batch.py
@@ -61,7 +61,7 @@ class BulkWriteBatch(BaseBatch):
                 system-specified value.
 
         Returns:
-            :class:`google.cloud.proto.firestore.v1.write.BatchWriteResponse`:
+            :class:`google.cloud.firestore_v1.write.BatchWriteResponse`:
             Container holding the write results corresponding to the changes
             committed, returned in the same order as the changes were applied to
             this batch. An individual write result contains an ``update_time``

--- a/google/cloud/firestore_v1/query.py
+++ b/google/cloud/firestore_v1/query.py
@@ -59,13 +59,13 @@ class Query(BaseQuery):
     Args:
         parent (:class:`~google.cloud.firestore_v1.collection.CollectionReference`):
             The collection that this query applies to.
-        projection (Optional[:class:`google.cloud.proto.firestore.v1.\
+        projection (Optional[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.Projection`]):
             A projection of document fields to limit the query results to.
-        field_filters (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+        field_filters (Optional[Tuple[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.FieldFilter`, ...]]):
             The filters to be applied in the query.
-        orders (Optional[Tuple[:class:`google.cloud.proto.firestore.v1.\
+        orders (Optional[Tuple[:class:`google.cloud.firestore_v1.\
             query.StructuredQuery.Order`, ...]]):
             The "order by" entries to use in the query.
         limit (Optional[int]):

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -63,7 +63,7 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         """Add `Write`` protobufs to this transaction.
 
         Args:
-            write_pbs (List[google.cloud.proto.firestore.v1.\
+            write_pbs (List[google.cloud.firestore_v1.\
                 write.Write]): A list of write protobufs to be added.
 
         Raises:
@@ -124,7 +124,7 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         """Transactionally commit the changes accumulated.
 
         Returns:
-            List[:class:`google.cloud.proto.firestore.v1.write.WriteResult`, ...]:
+            List[:class:`google.cloud.firestore_v1.write.WriteResult`, ...]:
             The write results corresponding to the changes committed, returned
             in the same order as the changes were applied to this transaction.
             A write result contains an ``update_time`` field.


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-firestore/issues/902

updates `google.cloud.proto.x` path references to `google.cloud.firestore_v1`, to match new structure 