### PR TITLE
fix: populate transaction attributes after commit

### DIFF
--- a/google/cloud/firestore_v1/async_transaction.py
+++ b/google/cloud/firestore_v1/async_transaction.py
@@ -145,7 +145,9 @@ class AsyncTransaction(async_batch.AsyncWriteBatch, BaseTransaction):
         )
 
         self._clean_up()
-        return list(commit_response.write_results)
+        self.write_results = list(commit_response.write_results)
+        self.commit_time = commit_response.commit_time
+        return self.write_results
 
     async def get_all(
         self,

--- a/google/cloud/firestore_v1/transaction.py
+++ b/google/cloud/firestore_v1/transaction.py
@@ -145,7 +145,9 @@ class Transaction(batch.WriteBatch, BaseTransaction):
         )
 
         self._clean_up()
-        return list(commit_response.write_results)
+        self.write_results = list(commit_response.write_results)
+        self.commit_time = commit_response.commit_time
+        return self.write_results
 
     def get_all(
         self,

--- a/tests/unit/v1/test_async_transaction.py
+++ b/tests/unit/v1/test_async_transaction.py
@@ -206,7 +206,9 @@ async def test_asynctransaction__commit():
     commit_time = Timestamp()
     commit_time.FromDatetime(datetime.datetime.now())
     results = [write.WriteResult(update_time=commit_time)]
-    commit_response = firestore.CommitResponse(write_results=results, commit_time=commit_time)
+    commit_response = firestore.CommitResponse(
+        write_results=results, commit_time=commit_time
+    )
     firestore_api.commit.return_value = commit_response
 
     # Attach the fake GAPIC to a real client.

--- a/tests/unit/v1/test_async_transaction.py
+++ b/tests/unit/v1/test_async_transaction.py
@@ -198,10 +198,15 @@ async def test_asynctransaction__rollback_failure():
 @pytest.mark.asyncio
 async def test_asynctransaction__commit():
     from google.cloud.firestore_v1.types import firestore, write
+    from google.protobuf.timestamp_pb2 import Timestamp
+    import datetime
 
     # Create a minimal fake GAPIC with a dummy result.
     firestore_api = AsyncMock()
-    commit_response = firestore.CommitResponse(write_results=[write.WriteResult()])
+    commit_time = Timestamp()
+    commit_time.FromDatetime(datetime.datetime.now())
+    results = [write.WriteResult(update_time=commit_time)]
+    commit_response = firestore.CommitResponse(write_results=results, commit_time=commit_time)
     firestore_api.commit.return_value = commit_response
 
     # Attach the fake GAPIC to a real client.
@@ -221,6 +226,9 @@ async def test_asynctransaction__commit():
     # Make sure transaction has no more "changes".
     assert transaction._id is None
     assert transaction._write_pbs == []
+    # ensure write_results and commit_time were set
+    assert transaction.write_results == results
+    assert transaction.commit_time.timestamp_pb() == commit_time
 
     # Verify the mocks.
     firestore_api.commit.assert_called_once_with(

--- a/tests/unit/v1/test_transaction.py
+++ b/tests/unit/v1/test_transaction.py
@@ -33,6 +33,8 @@ def test_transaction_constructor_defaults():
     assert transaction._max_attempts == MAX_ATTEMPTS
     assert not transaction._read_only
     assert transaction._id is None
+    assert transaction.write_results is None
+    assert transaction.commit_time is None
 
 
 def test_transaction_constructor_explicit():
@@ -209,12 +211,17 @@ def test_transaction__rollback_failure(database):
 def test_transaction__commit(database):
     from google.cloud.firestore_v1.services.firestore import client as firestore_client
     from google.cloud.firestore_v1.types import firestore, write
+    from google.protobuf.timestamp_pb2 import Timestamp
+    import datetime
 
     # Create a minimal fake GAPIC with a dummy result.
     firestore_api = mock.create_autospec(
         firestore_client.FirestoreClient, instance=True
     )
-    commit_response = firestore.CommitResponse(write_results=[write.WriteResult()])
+    commit_time = Timestamp()
+    commit_time.FromDatetime(datetime.datetime.now())
+    results = [write.WriteResult(update_time=commit_time)]
+    commit_response = firestore.CommitResponse(write_results=results, commit_time=commit_time)
     firestore_api.commit.return_value = commit_response
 
     # Attach the fake GAPIC to a real client.
@@ -234,6 +241,9 @@ def test_transaction__commit(database):
     # Make sure transaction has no more "changes".
     assert transaction._id is None
     assert transaction._write_pbs == []
+    # ensure write_results and commit_time were set
+    assert transaction.write_results == results
+    assert transaction.commit_time.timestamp_pb() == commit_time
 
     # Verify the mocks.
     firestore_api.commit.assert_called_once_with(

--- a/tests/unit/v1/test_transaction.py
+++ b/tests/unit/v1/test_transaction.py
@@ -221,7 +221,9 @@ def test_transaction__commit(database):
     commit_time = Timestamp()
     commit_time.FromDatetime(datetime.datetime.now())
     results = [write.WriteResult(update_time=commit_time)]
-    commit_response = firestore.CommitResponse(write_results=results, commit_time=commit_time)
+    commit_response = firestore.CommitResponse(
+        write_results=results, commit_time=commit_time
+    )
     firestore_api.commit.return_value = commit_response
 
     # Attach the fake GAPIC to a real client.


### PR DESCRIPTION
`Transaction` and `AsyncTransaction` inherit from `Batch`, which includes fields to store `write_results` and `commit_time` after commit is complete, but they are currently not populated for `Transaction` types. This PR addresses this by populating the fields with the commit response

Fixes https://github.com/googleapis/python-firestore/issues/927
