### PR TITLE
fix: client-side path validation for batch.update

### DIFF
--- a/google/cloud/firestore_v1/field_path.py
+++ b/google/cloud/firestore_v1/field_path.py
@@ -31,7 +31,6 @@ _BACKTICK = "`"
 _ESCAPED_BACKTICK = _BACKSLASH + _BACKTICK
 
 _SIMPLE_FIELD_NAME = re.compile("^[_a-zA-Z][_a-zA-Z0-9]*$")
-_LEADING_ALPHA_INVALID = re.compile("^[_a-zA-Z][_a-zA-Z0-9]*[^_a-zA-Z0-9]")
 PATH_ELEMENT_TOKENS = [
     ("SIMPLE", r"[_a-zA-Z][_a-zA-Z0-9]*"),  # unquoted elements
     ("QUOTED", r"`(?:\\`|[^`])*?`"),  # quoted elements, unquoted
@@ -309,12 +308,6 @@ class FieldPath(object):
             for element in elements:
                 if not element:
                     raise ValueError("Empty element")
-                if _LEADING_ALPHA_INVALID.match(element):
-                    raise ValueError(
-                        "Non-alphanum char in element with leading alpha: {}".format(
-                            element
-                        )
-                    )
             return FieldPath(*elements)
 
     def __repr__(self):

--- a/google/cloud/firestore_v1/field_path.py
+++ b/google/cloud/firestore_v1/field_path.py
@@ -31,6 +31,7 @@ _BACKTICK = "`"
 _ESCAPED_BACKTICK = _BACKSLASH + _BACKTICK
 
 _SIMPLE_FIELD_NAME = re.compile("^[_a-zA-Z][_a-zA-Z0-9]*$")
+_LEADING_ALPHA_INVALID = re.compile(r"^[_a-zA-Z][_a-zA-Z0-9]*[~*/\[\]]")
 PATH_ELEMENT_TOKENS = [
     ("SIMPLE", r"[_a-zA-Z][_a-zA-Z0-9]*"),  # unquoted elements
     ("QUOTED", r"`(?:\\`|[^`])*?`"),  # quoted elements, unquoted
@@ -308,6 +309,10 @@ class FieldPath(object):
             for element in elements:
                 if not element:
                     raise ValueError("Empty element")
+                if _LEADING_ALPHA_INVALID.match(element):
+                    raise ValueError(
+                        "Invalid char in element with leading alpha: {}".format(element)
+                    )
             return FieldPath(*elements)
 
     def __repr__(self):

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -3240,14 +3240,11 @@ def test_update_w_uuid(client, cleanup, database):
     doc_ref.create({key: "I'm a UUID!"})
 
     expected = "UPDATED VALUE"
-    doc_ref.update(
-        {
-            key: expected
-        }
-    )
+    doc_ref.update({key: expected})
     # read updated doc
     snapshot = doc_ref.get()
     assert snapshot.to_dict()[key] == expected
+
 
 @pytest.mark.parametrize("with_rollback,expected", [(True, 2), (False, 3)])
 @pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -3228,6 +3228,27 @@ def test_query_in_transaction_with_explain_options(client, cleanup, database):
         assert inner_fn_ran is True
 
 
+@pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
+def test_update_w_uuid(client, cleanup, database):
+    """
+    https://github.com/googleapis/python-firestore/issues/1012
+    """
+    collection_id = "uuid_collection" + UNIQUE_RESOURCE_ID
+    doc_ref = client.document(collection_id, "doc")
+    cleanup(doc_ref.delete)
+    key = "b7992822-eacb-40be-8af6-559b9e2fb0b7"
+    doc_ref.create({key: "I'm a UUID!"})
+
+    expected = "UPDATED VALUE"
+    doc_ref.update(
+        {
+            key: expected
+        }
+    )
+    # read updated doc
+    snapshot = doc_ref.get()
+    assert snapshot.to_dict()[key] == expected
+
 @pytest.mark.parametrize("with_rollback,expected", [(True, 2), (False, 3)])
 @pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
 def test_transaction_rollback(client, cleanup, database, with_rollback, expected):

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -3156,9 +3156,6 @@ def test_transaction_w_uuid(client, cleanup, database):
     """
     https://github.com/googleapis/python-firestore/issues/1012
     """
-    import uuid
-    from google.cloud.firestore_v1.services.firestore import client as firestore_client
-
     collection_id = "uuid_collection" + UNIQUE_RESOURCE_ID
     doc_ref = client.document(collection_id, "doc")
     cleanup(doc_ref.delete)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -3151,6 +3151,31 @@ def test_or_query_in_transaction(client, cleanup, database):
         assert inner_fn_ran is True
 
 
+@pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
+def test_transaction_w_uuid(client, cleanup, database):
+    """
+    https://github.com/googleapis/python-firestore/issues/1012
+    """
+    import uuid
+    from google.cloud.firestore_v1.services.firestore import client as firestore_client
+
+    collection_id = "uuid_collection" + UNIQUE_RESOURCE_ID
+    doc_ref = client.document(collection_id, "doc")
+    cleanup(doc_ref.delete)
+    key = "b7992822-eacb-40be-8af6-559b9e2fb0b7"
+    doc_ref.create({key: "I'm a UUID!"})
+
+    @firestore.transactional
+    def update_doc(tx, doc_ref, key, value):
+        tx.update(doc_ref, {key: value})
+
+    expected = "UPDATED VALUE"
+    update_doc(client.transaction(), doc_ref, key, expected)
+    # read updated doc
+    snapshot = doc_ref.get()
+    assert snapshot.to_dict()[key] == expected
+
+
 @pytest.mark.skipif(
     FIRESTORE_EMULATOR, reason="Query profile not supported in emulator."
 )


### PR DESCRIPTION
The _LEADING_ALPHA_INVALID check is too broad, triggering for more characters than the ones reported in the docstring. This is causing downstream issues, like [preventing unquoted references to uuid fields](https://github.com/googleapis/python-firestore/issues/1012). This PR reduces the scope of the validation, to check only against the invalid characters mentioned in the `FieldPath.from_string` docstring

Fixes https://github.com/googleapis/python-firestore/issues/1012
