### PR TITLE
chore: add java 21 to fix emulator tests

### DIFF
--- a/.github/workflows/system_emulated.yml
+++ b/.github/workflows/system_emulated.yml
@@ -19,6 +19,12 @@ jobs:
       with:
         python-version: '3.7'
 
+    # firestore sdk requires java 21+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+
     - name: Setup GCloud SDK
       uses: google-github-actions/setup-gcloud@v2.1.1
 

--- a/.github/workflows/system_emulated.yml
+++ b/.github/workflows/system_emulated.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
+        distribution: temurin
         java-version: '21'
 
     - name: Setup GCloud SDK

--- a/.github/workflows/system_emulated.yml
+++ b/.github/workflows/system_emulated.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: '3.7'
 
-    # firestore sdk requires java 21+
+    # firestore emulator requires java 21+
     - name: Setup Java
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
The system emulator tests are currently failing due to a Java version failure. This adds the version to the Github Action workflow
