### PR TITLE
chore: update renovate.json

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -147,7 +147,7 @@ templated_files = common.py_library(
 )
 
 s.move(templated_files,
-       excludes=[".github/release-please.yml"])
+       excludes=[".github/release-please.yml", "renovate.json"])
 
 python.py_samples(skip_readmes=True)
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/*"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
Renovate bot should ignore all Github Action workflows. We want tests to use fixed python versions, instead of having them update to latest
