### PR TITLE
chore: set system test version to 3.13

### DIFF
--- a/.kokoro/presubmit/system-3.13.cfg
+++ b/.kokoro/presubmit/system-3.13.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.13"
+}

--- a/.kokoro/presubmit/system.cfg
+++ b/.kokoro/presubmit/system.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.9"
+    value: "system-3.13"
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,7 +62,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.9", "3.14"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.13]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,7 +62,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.13]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.13"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/owlbot.py
+++ b/owlbot.py
@@ -144,7 +144,7 @@ templated_files = common.py_library(
     cov_level=100,
     split_system_tests=True,
     default_python_version="3.13",
-    system_test_python_versions=["3.9", "3.14"],
+    system_test_python_versions=["3.13"],
     unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"],
 )
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,4 @@ filterwarnings =
     # Remove after updating test dependencies that use asyncio.iscoroutinefunction
     ignore:.*\'asyncio.iscoroutinefunction\' is deprecated.*:DeprecationWarning
     ignore:.*\'asyncio.get_event_loop_policy\' is deprecated.*:DeprecationWarning
+    ignore:.*Please upgrade to the latest Python version.*:FutureWarning

--- a/tests/unit/v1/test_async_client.py
+++ b/tests/unit/v1/test_async_client.py
@@ -374,7 +374,9 @@ async def test_asyncclient_get_all_read_time():
 
 
 @pytest.mark.asyncio
-@pytest.mark.filterwarnings("ignore:coroutine method 'aclose' of 'AsyncIter' was never awaited:RuntimeWarning")
+@pytest.mark.filterwarnings(
+    "ignore:coroutine method 'aclose' of 'AsyncIter' was never awaited:RuntimeWarning"
+)
 async def test_asyncclient_get_all_unknown_result():
     from google.cloud.firestore_v1.base_client import _BAD_DOC_TEMPLATE
 

--- a/tests/unit/v1/test_async_client.py
+++ b/tests/unit/v1/test_async_client.py
@@ -374,6 +374,7 @@ async def test_asyncclient_get_all_read_time():
 
 
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:coroutine method 'aclose' of 'AsyncIter' was never awaited:RuntimeWarning")
 async def test_asyncclient_get_all_unknown_result():
     from google.cloud.firestore_v1.base_client import _BAD_DOC_TEMPLATE
 


### PR DESCRIPTION
As part of the 3.14 update, we set system tests to run on 3.9 and 3.14. This ended up slowing down the tests too significantly. This PR reverts the CI system to just run system tests against 3.13 again

Also filters out deprecation warnings for 3.7/3.8, and filters out a flaky warning
