### PR TITLE
chore: remove is_nan and is_null

### DIFF
--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -1603,7 +1603,10 @@ class Constant(Expression, Generic[CONSTANT_TYPE]):
         return Constant(value)
 
     def __repr__(self):
-        return f"Constant.of({self.value!r})"
+        value_str = repr(self.value)
+        if isinstance(self.value, float) and value_str == "nan":
+            value_str = "math.nan"
+        return f"Constant.of({value_str})"
 
     def __hash__(self):
         return hash(self.value)

--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -817,56 +817,6 @@ class Expression(ABC):
         )
 
     @expose_as_static
-    def is_nan(self) -> "BooleanExpression":
-        """Creates an expression that checks if this expression evaluates to 'NaN' (Not a Number).
-
-        Example:
-            >>> # Check if the result of a calculation is NaN
-            >>> Field.of("value").divide(0).is_nan()
-
-        Returns:
-            A new `Expression` representing the 'isNaN' check.
-        """
-        return BooleanExpression("is_nan", [self])
-
-    @expose_as_static
-    def is_not_nan(self) -> "BooleanExpression":
-        """Creates an expression that checks if this expression evaluates to a non-'NaN' (Not a Number) value.
-
-        Example:
-            >>> # Check if the result of a calculation is not NaN
-            >>> Field.of("value").divide(1).is_not_nan()
-
-        Returns:
-            A new `Expression` representing the 'is not NaN' check.
-        """
-        return BooleanExpression("is_not_nan", [self])
-
-    @expose_as_static
-    def is_null(self) -> "BooleanExpression":
-        """Creates an expression that checks if the value of a field is 'Null'.
-
-        Example:
-            >>> Field.of("value").is_null()
-
-        Returns:
-            A new `Expression` representing the 'isNull' check.
-        """
-        return BooleanExpression("is_null", [self])
-
-    @expose_as_static
-    def is_not_null(self) -> "BooleanExpression":
-        """Creates an expression that checks if the value of a field is not 'Null'.
-
-        Example:
-            >>> Field.of("value").is_not_null()
-
-        Returns:
-            A new `Expression` representing the 'isNotNull' check.
-        """
-        return BooleanExpression("is_not_null", [self])
-
-    @expose_as_static
     def is_error(self):
         """Creates an expression that checks if a given expression produces an error
 
@@ -1827,13 +1777,13 @@ class BooleanExpression(Function):
         elif isinstance(filter_pb, Query_pb.UnaryFilter):
             field = Field.of(filter_pb.field.field_path)
             if filter_pb.op == Query_pb.UnaryFilter.Operator.IS_NAN:
-                return And(field.exists(), field.is_nan())
+                return And(field.exists(), field.equal(float("nan")))
             elif filter_pb.op == Query_pb.UnaryFilter.Operator.IS_NOT_NAN:
-                return And(field.exists(), field.is_not_nan())
+                return And(field.exists(), Not(field.equal(float("nan"))))
             elif filter_pb.op == Query_pb.UnaryFilter.Operator.IS_NULL:
-                return And(field.exists(), field.is_null())
+                return And(field.exists(), field.equal(None))
             elif filter_pb.op == Query_pb.UnaryFilter.Operator.IS_NOT_NULL:
-                return And(field.exists(), field.is_not_null())
+                return And(field.exists(), Not(field.equal(None)))
             else:
                 raise TypeError(f"Unexpected UnaryFilter operator type: {filter_pb.op}")
         elif isinstance(filter_pb, Query_pb.FieldFilter):

--- a/tests/system/pipeline_e2e/array.yaml
+++ b/tests/system/pipeline_e2e/array.yaml
@@ -185,7 +185,7 @@ tests:
         - AliasedExpression:
             - Function.array_concat:
                 - Field: tags
-                - Constant: ["new_tag", "another_tag"]
+                - ["new_tag", "another_tag"]
             - "concatenatedTags"
     assert_results:
       - concatenatedTags:
@@ -232,8 +232,8 @@ tests:
         - AliasedExpression:
             - Function.array_concat:
                 - Field: tags
-                - Constant: ["sci-fi"]
-                - Constant: ["classic", "epic"]
+                - ["sci-fi"]
+                - ["classic", "epic"]
             - "concatenatedTags"
     assert_results:
       - concatenatedTags:

--- a/tests/system/pipeline_e2e/data.yaml
+++ b/tests/system/pipeline_e2e/data.yaml
@@ -140,3 +140,8 @@ data:
       embedding: [5.0, 6.0, 7.0]
     vec4:
       embedding: [1.0, 2.0, 4.0]
+  errors:
+    doc_with_nan:
+      value: "NaN"
+    doc_with_null:
+      value: null

--- a/tests/system/pipeline_e2e/logical.yaml
+++ b/tests/system/pipeline_e2e/logical.yaml
@@ -238,22 +238,15 @@ tests:
                 expression:
                   fieldReferenceValue: title
           name: sort
-  - description: testChecks
+  - description: testIsNotNull
     pipeline:
       - Collection: books
       - Where:
-            - Not:
-                - Function.is_nan:
-                  - Field: rating
-      - Select:
-          - AliasedExpression:
-              - Not:
-                  - Function.is_nan:
-                    - Field: rating
-              - "ratingIsNotNaN"
-      - Limit: 1
-    assert_results:
-      - ratingIsNotNaN: true
+          - Not:
+            - Function.equal:
+                - Field: rating
+                - null
+    assert_count: 10
     assert_proto:
       pipeline:
         stages:
@@ -266,30 +259,18 @@ tests:
               - functionValue:
                   args:
                   - fieldReferenceValue: rating
-                  name: is_nan
+                  - nullValue: null
+                  name: equal
               name: not
           name: where
-        - args:
-          - mapValue:
-              fields:
-                ratingIsNotNaN:
-                  functionValue:
-                    args:
-                    - functionValue:
-                        args:
-                        - fieldReferenceValue: rating
-                        name: is_nan
-                    name: not
-          name: select
-        - args:
-          - integerValue: '1'
-          name: limit
-  - description: testIsNotNull
+  - description: testIsNotNan
     pipeline:
       - Collection: books
       - Where:
-          - Function.is_not_null:
-              - Field: rating
+          - Not:
+            - Function.equal:
+                - Field: rating
+                - NaN
     assert_count: 10
     assert_proto:
       pipeline:
@@ -300,27 +281,12 @@ tests:
         - args:
           - functionValue:
               args:
-              - fieldReferenceValue: rating
-              name: is_not_null
-          name: where
-  - description: testIsNotNaN
-    pipeline:
-      - Collection: books
-      - Where:
-          - Function.is_not_nan:
-              - Field: rating
-    assert_count: 10
-    assert_proto:
-      pipeline:
-        stages:
-        - args:
-          - referenceValue: /books
-          name: collection
-        - args:
-          - functionValue:
-              args:
-              - fieldReferenceValue: rating
-              name: is_not_nan
+              - functionValue:
+                  args:
+                  - fieldReferenceValue: rating
+                  - doubleValue: NaN
+                  name: equal
+              name: not
           name: where
   - description: testIsAbsent
     pipeline:

--- a/tests/system/pipeline_e2e/logical.yaml
+++ b/tests/system/pipeline_e2e/logical.yaml
@@ -238,55 +238,48 @@ tests:
                 expression:
                   fieldReferenceValue: title
           name: sort
-  - description: testIsNotNull
+  - description: testIsNull
     pipeline:
-      - Collection: books
+      - Collection: errors
       - Where:
-          - Not:
-            - Function.equal:
-                - Field: rating
-                - null
-    assert_count: 10
+        - Function.equal:
+            - Field: value
+            - null
+    assert_results:
+      - value: null
     assert_proto:
       pipeline:
         stages:
         - args:
-          - referenceValue: /books
+          - referenceValue: /errors
           name: collection
         - args:
           - functionValue:
               args:
-              - functionValue:
-                  args:
-                  - fieldReferenceValue: rating
-                  - nullValue: null
-                  name: equal
-              name: not
+              - fieldReferenceValue: value
+              - nullValue: null
+              name: equal
           name: where
-  - description: testIsNotNan
+  - description: testIsNan
     pipeline:
-      - Collection: books
+      - Collection: errors
       - Where:
-          - Not:
-            - Function.equal:
-                - Field: rating
-                - NaN
-    assert_count: 10
+        - Function.equal:
+            - Field: value
+            - NaN
+    assert_count: 1
     assert_proto:
       pipeline:
         stages:
         - args:
-          - referenceValue: /books
+          - referenceValue: /errors
           name: collection
         - args:
           - functionValue:
               args:
-              - functionValue:
-                  args:
-                  - fieldReferenceValue: rating
-                  - doubleValue: NaN
-                  name: equal
-              name: not
+              - fieldReferenceValue: value
+              - doubleValue: NaN
+              name: equal
           name: where
   - description: testIsAbsent
     pipeline:

--- a/tests/system/test_pipeline_acceptance.py
+++ b/tests/system/test_pipeline_acceptance.py
@@ -353,6 +353,8 @@ def _parse_yaml_types(data):
             return parsed_datetime
         except ValueError:
             pass
+    if data == "NaN":
+        return float("NaN")
     return data
 
 

--- a/tests/system/test_pipeline_acceptance.py
+++ b/tests/system/test_pipeline_acceptance.py
@@ -270,7 +270,7 @@ def _parse_expressions(client, yaml_element: Any):
             }
     elif _is_expr_string(yaml_element):
         return getattr(pipeline_expressions, yaml_element)()
-    elif yaml_element == 'NaN':
+    elif yaml_element == "NaN":
         return float(yaml_element)
     else:
         return yaml_element

--- a/tests/system/test_pipeline_acceptance.py
+++ b/tests/system/test_pipeline_acceptance.py
@@ -270,6 +270,8 @@ def _parse_expressions(client, yaml_element: Any):
             }
     elif _is_expr_string(yaml_element):
         return getattr(pipeline_expressions, yaml_element)()
+    elif yaml_element == 'NaN':
+        return float(yaml_element)
     else:
         return yaml_element
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1727,7 +1727,7 @@ def test_query_with_order_dot_key(client, cleanup, database):
     assert found_data == [snap.to_dict() for snap in cursor_with_key_data]
 
 
-@pytest.mark.parametrize("database", TEST_DATABASES_W_ENTERPRISE, indirect=True)
+@pytest.mark.parametrize("database", TEST_DATABASES, indirect=True)
 def test_query_unary(client, cleanup, database):
     collection_name = "unary" + UNIQUE_RESOURCE_ID
     collection = client.collection(collection_name)
@@ -3287,7 +3287,7 @@ def test_query_with_or_composite_filter(collection, database):
     verify_pipeline(query)
 
 
-@pytest.mark.parametrize("database", TEST_DATABASES_W_ENTERPRISE, indirect=True)
+@pytest.mark.parametrize("database", TEST_DATABASES, indirect=True)
 @pytest.mark.parametrize(
     "aggregation_type,expected_value", [("count", 5), ("sum", 100), ("avg", 4.0)]
 )

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1651,7 +1651,7 @@ async def test_query_with_order_dot_key(client, cleanup, database):
     assert found_data == [snap.to_dict() for snap in cursor_with_key_data]
 
 
-@pytest.mark.parametrize("database", TEST_DATABASES_W_ENTERPRISE, indirect=True)
+@pytest.mark.parametrize("database", TEST_DATABASES, indirect=True)
 async def test_query_unary(client, cleanup, database):
     collection_name = "unary" + UNIQUE_RESOURCE_ID
     collection = client.collection(collection_name)

--- a/tests/unit/v1/test_pipeline_expressions.py
+++ b/tests/unit/v1/test_pipeline_expressions.py
@@ -121,6 +121,7 @@ class TestConstant:
     @pytest.mark.parametrize("input", [float("nan"), math.nan])
     def test_nan_to_pb(self, input):
         instance = Constant.of(input)
+        assert repr(instance) == "Constant.of(math.nan)"
         pb_val = instance._to_pb()
         assert math.isnan(pb_val.double_value)
 

--- a/tests/unit/v1/test_pipeline_expressions.py
+++ b/tests/unit/v1/test_pipeline_expressions.py
@@ -284,7 +284,7 @@ class TestBooleanExpression:
         field1 = Field.of("field1")
         field2 = Field.of("field2")
         expected_cond1 = expr.And(field1.exists(), field1.equal(Constant("val1")))
-        expected_cond2 = expr.And(field2.exists(), field2.is_null())
+        expected_cond2 = expr.And(field2.exists(), field2.equal(None))
         expected = expr.Or(expected_cond1, expected_cond2)
 
         assert repr(result) == repr(expected)
@@ -371,7 +371,7 @@ class TestBooleanExpression:
         field3 = Field.of("field3")
         expected_cond1 = expr.And(field1.exists(), field1.equal(Constant("val1")))
         expected_cond2 = expr.And(field2.exists(), field2.greater_than(Constant(10)))
-        expected_cond3 = expr.And(field3.exists(), field3.is_not_null())
+        expected_cond3 = expr.And(field3.exists(), expr.Not(field3.equal(None)))
         expected_inner_and = expr.And(expected_cond2, expected_cond3)
         expected_outer_or = expr.Or(expected_cond1, expected_inner_and)
 
@@ -400,18 +400,18 @@ class TestBooleanExpression:
     @pytest.mark.parametrize(
         "op_enum, expected_expr_func",
         [
-            (query_pb.StructuredQuery.UnaryFilter.Operator.IS_NAN, Expression.is_nan),
+            (query_pb.StructuredQuery.UnaryFilter.Operator.IS_NAN, lambda x: x.equal(float("nan"))),
             (
                 query_pb.StructuredQuery.UnaryFilter.Operator.IS_NOT_NAN,
-                Expression.is_not_nan,
+                lambda x: expr.Not(x.equal(float("nan"))),
             ),
             (
                 query_pb.StructuredQuery.UnaryFilter.Operator.IS_NULL,
-                Expression.is_null,
+                lambda x: x.equal(None),
             ),
             (
                 query_pb.StructuredQuery.UnaryFilter.Operator.IS_NOT_NULL,
-                Expression.is_not_null,
+                lambda x: expr.Not(x.equal(None)),
             ),
         ],
     )
@@ -844,42 +844,6 @@ class TestExpressionessionMethods:
         assert instance.params == [arg1, arg2]
         assert repr(instance) == "Field.if_absent(ThenExpression)"
         infix_instance = arg1.if_absent(arg2)
-        assert infix_instance == instance
-
-    def test_is_nan(self):
-        arg1 = self._make_arg("Value")
-        instance = Expression.is_nan(arg1)
-        assert instance.name == "is_nan"
-        assert instance.params == [arg1]
-        assert repr(instance) == "Value.is_nan()"
-        infix_instance = arg1.is_nan()
-        assert infix_instance == instance
-
-    def test_is_not_nan(self):
-        arg1 = self._make_arg("Value")
-        instance = Expression.is_not_nan(arg1)
-        assert instance.name == "is_not_nan"
-        assert instance.params == [arg1]
-        assert repr(instance) == "Value.is_not_nan()"
-        infix_instance = arg1.is_not_nan()
-        assert infix_instance == instance
-
-    def test_is_null(self):
-        arg1 = self._make_arg("Value")
-        instance = Expression.is_null(arg1)
-        assert instance.name == "is_null"
-        assert instance.params == [arg1]
-        assert repr(instance) == "Value.is_null()"
-        infix_instance = arg1.is_null()
-        assert infix_instance == instance
-
-    def test_is_not_null(self):
-        arg1 = self._make_arg("Value")
-        instance = Expression.is_not_null(arg1)
-        assert instance.name == "is_not_null"
-        assert instance.params == [arg1]
-        assert repr(instance) == "Value.is_not_null()"
-        infix_instance = arg1.is_not_null()
         assert infix_instance == instance
 
     def test_is_error(self):

--- a/tests/unit/v1/test_pipeline_expressions.py
+++ b/tests/unit/v1/test_pipeline_expressions.py
@@ -14,6 +14,7 @@
 
 import pytest
 import mock
+import math
 import datetime
 
 from google.cloud.firestore_v1 import _helpers
@@ -116,6 +117,12 @@ class TestConstant:
     def test_to_pb(self, input_val, to_pb_val):
         instance = Constant.of(input_val)
         assert instance._to_pb() == to_pb_val
+
+    @pytest.mark.parametrize("input", [float("nan"), math.nan])
+    def test_nan_to_pb(self, input):
+        instance = Constant.of(input)
+        pb_val = instance._to_pb()
+        assert math.isnan(pb_val.double_value)
 
     @pytest.mark.parametrize(
         "input_val,expected",

--- a/tests/unit/v1/test_pipeline_expressions.py
+++ b/tests/unit/v1/test_pipeline_expressions.py
@@ -408,7 +408,10 @@ class TestBooleanExpression:
     @pytest.mark.parametrize(
         "op_enum, expected_expr_func",
         [
-            (query_pb.StructuredQuery.UnaryFilter.Operator.IS_NAN, lambda x: x.equal(float("nan"))),
+            (
+                query_pb.StructuredQuery.UnaryFilter.Operator.IS_NAN,
+                lambda x: x.equal(float("nan")),
+            ),
             (
                 query_pb.StructuredQuery.UnaryFilter.Operator.IS_NOT_NAN,
                 lambda x: expr.Not(x.equal(float("nan"))),


### PR DESCRIPTION
These expressions are being removed in favor of `.equal(None)` and `.equal(float('nan'))`