### PR TITLE
feat: pipeline explain stats and index mode

### DIFF
--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -101,6 +101,4 @@ class AsyncPipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
         """
-        request = self._prep_execute_request(transaction, explain_options)
-        stream = self._client._firestore_api.execute_pipeline(request)
-        return AsyncPipelineStream(stream, self, explain_options)
+        return AsyncPipelineStream(self, transaction, explain_options)

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -18,10 +18,10 @@ from google.cloud.firestore_v1 import pipeline_stages as stages
 from google.cloud.firestore_v1.base_pipeline import _BasePipeline
 from google.cloud.firestore_v1.pipeline_result import AsyncPipelineStream
 from google.cloud.firestore_v1.pipeline_result import PipelineSnapshot
+from google.cloud.firestore_v1.pipeline_result import PipelineResult
 
 if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.async_client import AsyncClient
-    from google.cloud.firestore_v1.pipeline_result import PipelineResult
     from google.cloud.firestore_v1.async_transaction import AsyncTransaction
     from google.cloud.firestore_v1.query_profile import ExplainOptions
 
@@ -101,4 +101,6 @@ class AsyncPipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
         """
-        return AsyncPipelineStream(self, transaction, explain_options)
+        return AsyncPipelineStream(
+            PipelineResult, self, transaction, explain_options
+        )

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.async_client import AsyncClient
     from google.cloud.firestore_v1.pipeline_result import PipelineResult
     from google.cloud.firestore_v1.async_transaction import AsyncTransaction
+    from google.cloud.firestore_v1.query_profile import ExplainOptions
 
 
 class AsyncPipeline(_BasePipeline):
@@ -58,37 +59,45 @@ class AsyncPipeline(_BasePipeline):
 
     async def execute(
         self,
+        *,
         transaction: "AsyncTransaction" | None = None,
+        explain_options: ExplainOptions | None = None,
     ) -> list[PipelineResult]:
         """
         Executes this pipeline and returns results as a list
 
         Args:
-            transaction
-                (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+                Options to enable query profiling for this query. When set,
+                explain_metrics will be available on the returned list.
         """
-        return [result async for result in self.stream(transaction=transaction)]
+        return [result async for result in self.stream(transaction=transaction, explain_options=explain_options)]
 
     async def stream(
         self,
+        *,
         transaction: "AsyncTransaction" | None = None,
+        explain_options: ExplainOptions | None = None,
     ) -> AsyncIterable[PipelineResult]:
         """
         Process this pipeline as a stream, providing results through an Iterable
 
         Args:
-            transaction
-                (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+                Options to enable query profiling for this query. When set,
+                explain_metrics will be available on the returned generator.
         """
-        request = self._prep_execute_request(transaction)
+        request = self._prep_execute_request(transaction, explain_options)
         async for response in await self._client._firestore_api.execute_pipeline(
             request
         ):

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -80,7 +80,7 @@ class AsyncPipeline(_BasePipeline):
         """
         stream = self.stream(transaction=transaction, explain_options=explain_options)
         results = [result async for result in stream]
-        return await PipelineSnapshot._from_stream(results, stream)
+        return PipelineSnapshot(results, stream)
 
     def stream(
         self,

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.async_transaction import AsyncTransaction
     from google.cloud.firestore_v1.pipeline_expressions import Constant
     from google.cloud.firestore_v1.types.document import Value
-    from google.cloud.firestore_v1.query_profile import ExplainOptions
+    from google.cloud.firestore_v1.query_profile import PipelineExplainOptions
 
 
 class AsyncPipeline(_BasePipeline):
@@ -65,7 +65,7 @@ class AsyncPipeline(_BasePipeline):
         self,
         *,
         transaction: "AsyncTransaction" | None = None,
-        explain_options: ExplainOptions | None = None,
+        explain_options: PipelineExplainOptions | None = None,
         index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineSnapshot[PipelineResult]:
@@ -78,7 +78,7 @@ class AsyncPipeline(_BasePipeline):
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
-            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
             index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
@@ -95,7 +95,7 @@ class AsyncPipeline(_BasePipeline):
         self,
         *,
         transaction: "AsyncTransaction" | None = None,
-        explain_options: ExplainOptions | None = None,
+        explain_options: PipelineExplainOptions | None = None,
         index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> AsyncPipelineStream[PipelineResult]:
@@ -108,7 +108,7 @@ class AsyncPipeline(_BasePipeline):
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
-            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
             index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import AsyncIterable, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from google.cloud.firestore_v1 import pipeline_stages as stages
 from google.cloud.firestore_v1.base_pipeline import _BasePipeline
 from google.cloud.firestore_v1.pipeline_result import AsyncPipelineStream
@@ -23,6 +23,8 @@ from google.cloud.firestore_v1.pipeline_result import PipelineResult
 if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.async_client import AsyncClient
     from google.cloud.firestore_v1.async_transaction import AsyncTransaction
+    from google.cloud.firestore_v1.pipeline_expressions import Constant
+    from google.cloud.firestore_v1.types.document import Value
     from google.cloud.firestore_v1.query_profile import ExplainOptions
 
 
@@ -84,7 +86,7 @@ class AsyncPipeline(_BasePipeline):
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
                 These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
-        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        kwargs = {k: v for k, v in locals().items() if k != "self"}
         stream = AsyncPipelineStream(PipelineResult, self, **kwargs)
         results = [result async for result in stream]
         return PipelineSnapshot(results, stream)
@@ -114,5 +116,5 @@ class AsyncPipeline(_BasePipeline):
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
                 These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
-        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        kwargs = {k: v for k, v in locals().items() if k != "self"}
         return AsyncPipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -78,7 +78,8 @@ class AsyncPipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
         """
-        stream = self.stream(transaction=transaction, explain_options=explain_options)
+        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        stream = AsyncPipelineStream(PipelineResult, self, **kwargs)
         results = [result async for result in stream]
         return PipelineSnapshot(results, stream)
 
@@ -101,6 +102,5 @@ class AsyncPipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
         """
-        return AsyncPipelineStream(
-            PipelineResult, self, transaction, explain_options
-        )
+        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        return AsyncPipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -64,6 +64,8 @@ class AsyncPipeline(_BasePipeline):
         *,
         transaction: "AsyncTransaction" | None = None,
         explain_options: ExplainOptions | None = None,
+        index_mode: str | None = None,
+        additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineSnapshot[PipelineResult]:
         """
         Executes this pipeline and returns results as a list
@@ -77,6 +79,10 @@ class AsyncPipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
+            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
+                Firestore will reject the request if there is not appropiate indexes to serve the query.
+            additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
         kwargs = {k: v for k, v in locals().items() if k != 'self'}
         stream = AsyncPipelineStream(PipelineResult, self, **kwargs)
@@ -88,6 +94,8 @@ class AsyncPipeline(_BasePipeline):
         *,
         transaction: "AsyncTransaction" | None = None,
         explain_options: ExplainOptions | None = None,
+        index_mode: str | None = None,
+        additional_options: dict[str, Value | Constant] = {},
     ) -> AsyncPipelineStream[PipelineResult]:
         """
         Process this pipeline as a stream, providing results through an AsyncIterable
@@ -101,6 +109,10 @@ class AsyncPipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
+            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
+                Firestore will reject the request if there is not appropiate indexes to serve the query.
+            additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
         kwargs = {k: v for k, v in locals().items() if k != 'self'}
         return AsyncPipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/base_pipeline.py
+++ b/google/cloud/firestore_v1/base_pipeline.py
@@ -100,49 +100,6 @@ class _BasePipeline:
         """
         return self.__class__._create_with_stages(self._client, *self.stages, new_stage)
 
-    def _prep_execute_request(
-        self,
-        transaction: BaseTransaction | None,
-        explain_options: ExplainOptions | None,
-    ) -> ExecutePipelineRequest:
-        """
-        shared logic for creating an ExecutePipelineRequest
-        """
-        database_name = (
-            f"projects/{self._client.project}/databases/{self._client._database}"
-        )
-        transaction_id = (
-            _helpers.get_transaction_id(transaction)
-            if transaction is not None
-            else None
-        )
-        options = {}
-        if explain_options:
-            options["explain_options"] = explain_options._to_value()
-        request = ExecutePipelineRequest(
-            database=database_name,
-            transaction=transaction_id,
-            structured_pipeline=self._to_pb(**options)
-        )
-        return request
-
-    def _execute_response_helper(
-        self, response: ExecutePipelineResponse
-    ) -> Iterable[PipelineResult]:
-        """
-        shared logic for unpacking an ExecutePipelineReponse into PipelineResults
-        """
-        for doc in response.results:
-            ref = self._client.document(doc.name) if doc.name else None
-            yield PipelineResult(
-                self._client,
-                doc.fields,
-                ref,
-                response._pb.execution_time,
-                doc._pb.create_time if doc.create_time else None,
-                doc._pb.update_time if doc.update_time else None,
-            )
-
     def add_fields(self, *fields: Selectable) -> "_BasePipeline":
         """
         Adds new fields to outputs from previous stages.

--- a/google/cloud/firestore_v1/base_pipeline.py
+++ b/google/cloud/firestore_v1/base_pipeline.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Iterable, Sequence, TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING
 from google.cloud.firestore_v1 import pipeline_stages as stages
 from google.cloud.firestore_v1.types.pipeline import (
     StructuredPipeline as StructuredPipeline_pb,
 )
 from google.cloud.firestore_v1.vector import Vector
 from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
-from google.cloud.firestore_v1.types.firestore import ExecutePipelineRequest
-from google.cloud.firestore_v1.pipeline_result import PipelineResult
 from google.cloud.firestore_v1.pipeline_expressions import (
     AggregateFunction,
     AliasedExpression,
@@ -30,14 +28,10 @@ from google.cloud.firestore_v1.pipeline_expressions import (
     BooleanExpression,
     Selectable,
 )
-from google.cloud.firestore_v1 import _helpers
 
 if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.client import Client
     from google.cloud.firestore_v1.async_client import AsyncClient
-    from google.cloud.firestore_v1.types.firestore import ExecutePipelineResponse
-    from google.cloud.firestore_v1.transaction import BaseTransaction
-    from google.cloud.firestore_v1.query_profile import ExplainOptions
 
 
 class _BasePipeline:

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.pipeline_expressions import Constant
     from google.cloud.firestore_v1.transaction import Transaction
     from google.cloud.firestore_v1.types.document import Value
-    from google.cloud.firestore_v1.query_profile import ExplainOptions
+    from google.cloud.firestore_v1.query_profile import PipelineExplainOptions
 
 
 class Pipeline(_BasePipeline):
@@ -62,7 +62,7 @@ class Pipeline(_BasePipeline):
         self,
         *,
         transaction: "Transaction" | None = None,
-        explain_options: ExplainOptions | None = None,
+        explain_options: PipelineExplainOptions | None = None,
         index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineSnapshot[PipelineResult]:
@@ -75,7 +75,7 @@ class Pipeline(_BasePipeline):
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
-            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
             index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
@@ -92,7 +92,7 @@ class Pipeline(_BasePipeline):
         self,
         *,
         transaction: "Transaction" | None = None,
-        explain_options: ExplainOptions | None = None,
+        explain_options: PipelineExplainOptions | None = None,
         index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineStream[PipelineResult]:
@@ -105,7 +105,7 @@ class Pipeline(_BasePipeline):
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
-            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
             index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -62,6 +62,8 @@ class Pipeline(_BasePipeline):
         *,
         transaction: "Transaction" | None = None,
         explain_options: ExplainOptions | None = None,
+        index_mode: str | None = None,
+        additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineSnapshot[PipelineResult]:
         """
         Executes this pipeline and returns results as a list
@@ -75,6 +77,10 @@ class Pipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
+            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
+                Firestore will reject the request if there is not appropiate indexes to serve the query.
+            additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
         kwargs = {k: v for k, v in locals().items() if k != 'self'}
         stream = PipelineStream(PipelineResult, self, **kwargs)
@@ -86,6 +92,8 @@ class Pipeline(_BasePipeline):
         *,
         transaction: "Transaction" | None = None,
         explain_options: ExplainOptions | None = None,
+        index_mode: str | None = None,
+        additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineStream[PipelineResult]:
         """
         Process this pipeline as a stream, providing results through an Iterable
@@ -99,6 +107,10 @@ class Pipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
+            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
+                Firestore will reject the request if there is not appropiate indexes to serve the query.
+            additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
         kwargs = {k: v for k, v in locals().items() if k != 'self'}
         return PipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -99,6 +99,4 @@ class Pipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
         """
-        request = self._prep_execute_request(transaction, explain_options)
-        stream = self._client._firestore_api.execute_pipeline(request)
-        return PipelineStream(stream, self, explain_options)
+        return PipelineStream(self, transaction, explain_options)

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.client import Client
     from google.cloud.firestore_v1.pipeline_result import PipelineResult
     from google.cloud.firestore_v1.transaction import Transaction
+    from google.cloud.firestore_v1.query_profile import ExplainOptions
 
 
 class Pipeline(_BasePipeline):
@@ -55,36 +56,44 @@ class Pipeline(_BasePipeline):
 
     def execute(
         self,
+        *,
         transaction: "Transaction" | None = None,
+        explain_options: ExplainOptions | None = None,
     ) -> list[PipelineResult]:
         """
         Executes this pipeline and returns results as a list
 
         Args:
-            transaction
-                (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+                Options to enable query profiling for this query. When set,
+                explain_metrics will be available on the returned list.
         """
-        return [result for result in self.stream(transaction=transaction)]
+        return [result for result in self.stream(transaction=transaction, explain_options=explain_options)]
 
     def stream(
         self,
+        *,
         transaction: "Transaction" | None = None,
+        explain_options: ExplainOptions | None = None,
     ) -> Iterable[PipelineResult]:
         """
         Process this pipeline as a stream, providing results through an Iterable
 
         Args:
-            transaction
-                (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
+            transaction (Optional[:class:`~google.cloud.firestore_v1.transaction.Transaction`]):
                 An existing transaction that this query will run in.
                 If a ``transaction`` is used and it already has write operations
                 added, this method cannot be used (i.e. read-after-write is not
                 allowed).
+            explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.ExplainOptions`]):
+                Options to enable query profiling for this query. When set,
+                explain_metrics will be available on the returned generator.
         """
-        request = self._prep_execute_request(transaction)
+        request = self._prep_execute_request(transaction, explain_options)
         for response in self._client._firestore_api.execute_pipeline(request):
             yield from self._execute_response_helper(response)

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -76,7 +76,9 @@ class Pipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
         """
-        return PipelineSnapshot._from_stream(self.stream(transaction=transaction, explain_options=explain_options))
+        stream = self.stream(transaction=transaction, explain_options=explain_options)
+        results = [result for result in stream]
+        return PipelineSnapshot._from_stream(results, stream)
 
     def stream(
         self,

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -18,10 +18,10 @@ from google.cloud.firestore_v1 import pipeline_stages as stages
 from google.cloud.firestore_v1.base_pipeline import _BasePipeline
 from google.cloud.firestore_v1.pipeline_result import PipelineStream
 from google.cloud.firestore_v1.pipeline_result import PipelineSnapshot
+from google.cloud.firestore_v1.pipeline_result import PipelineResult
 
 if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.client import Client
-    from google.cloud.firestore_v1.pipeline_result import PipelineResult
     from google.cloud.firestore_v1.transaction import Transaction
     from google.cloud.firestore_v1.query_profile import ExplainMetrics
     from google.cloud.firestore_v1.query_profile import ExplainOptions
@@ -99,4 +99,6 @@ class Pipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
         """
-        return PipelineStream(self, transaction, explain_options)
+        return PipelineStream(
+            PipelineResult, self, transaction, explain_options
+        )

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -78,7 +78,7 @@ class Pipeline(_BasePipeline):
         """
         stream = self.stream(transaction=transaction, explain_options=explain_options)
         results = [result for result in stream]
-        return PipelineSnapshot._from_stream(results, stream)
+        return PipelineSnapshot(results, stream)
 
     def stream(
         self,

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Iterable, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from google.cloud.firestore_v1 import pipeline_stages as stages
 from google.cloud.firestore_v1.base_pipeline import _BasePipeline
 from google.cloud.firestore_v1.pipeline_result import PipelineStream
@@ -22,8 +22,9 @@ from google.cloud.firestore_v1.pipeline_result import PipelineResult
 
 if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.client import Client
+    from google.cloud.firestore_v1.pipeline_expressions import Constant
     from google.cloud.firestore_v1.transaction import Transaction
-    from google.cloud.firestore_v1.query_profile import ExplainMetrics
+    from google.cloud.firestore_v1.types.document import Value
     from google.cloud.firestore_v1.query_profile import ExplainOptions
 
 
@@ -82,7 +83,7 @@ class Pipeline(_BasePipeline):
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
                 These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
-        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        kwargs = {k: v for k, v in locals().items() if k != "self"}
         stream = PipelineStream(PipelineResult, self, **kwargs)
         results = [result for result in stream]
         return PipelineSnapshot(results, stream)
@@ -112,5 +113,5 @@ class Pipeline(_BasePipeline):
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
                 These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
         """
-        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        kwargs = {k: v for k, v in locals().items() if k != "self"}
         return PipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -76,7 +76,8 @@ class Pipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
         """
-        stream = self.stream(transaction=transaction, explain_options=explain_options)
+        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        stream = PipelineStream(PipelineResult, self, **kwargs)
         results = [result for result in stream]
         return PipelineSnapshot(results, stream)
 
@@ -99,6 +100,5 @@ class Pipeline(_BasePipeline):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
         """
-        return PipelineStream(
-            PipelineResult, self, transaction, explain_options
-        )
+        kwargs = {k: v for k, v in locals().items() if k != 'self'}
+        return PipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -99,4 +99,4 @@ class Pipeline(_BasePipeline):
         """
         request = self._prep_execute_request(transaction, explain_options)
         stream = self._client._firestore_api.execute_pipeline(request)
-        return PipelineStream(self._client, stream)
+        return PipelineStream(stream, self, explain_options)

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -20,7 +20,6 @@ from google.cloud.firestore_v1.field_path import get_nested_value
 from google.cloud.firestore_v1.field_path import FieldPath
 from google.cloud.firestore_v1.query_profile import ExplainStats
 from google.cloud.firestore_v1.query_profile import QueryExplainError
-from google.cloud.firestore_v1.query_profile import ExplainStats
 from google.cloud.firestore_v1.types.firestore import ExecutePipelineRequest
 
 if TYPE_CHECKING:  # pragma: NO COVER

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 from typing import Any, Awaitable, AsyncIterable, Iterable, MutableMapping, TYPE_CHECKING
+import copy
 from google.cloud.firestore_v1 import _helpers
 from google.cloud.firestore_v1.field_path import get_nested_value
 from google.cloud.firestore_v1.field_path import FieldPath
@@ -226,17 +227,11 @@ class PipelineSnapshot(_PipelineResultContainer, list[PipelineResult]):
     """
     A list type that holds the result of a pipeline.execute() operation, along with related metadata
     """
-    def __init__(self, results_list: list[PipelineResult], *args):
-        super().__init__(*args)
+    def __init__(self, results_list: list[PipelineResult], source: _PipelineResultContainer):
+        self.__dict__.update(copy.deepcopy(source.__dict__))
         list.__init__(self, results_list)
-        # snapshots are always completed
+        # snapshots are always complete
         self._started = True
-
-    @classmethod
-    def _from_stream(cls, results: list[PipelineResult], source: _PipelineResultContainer):
-        new_instance = cls(results, source.pipeline, source.transaction, source._explain_stats)
-        new_instance._explain_stats = source._explain_stats
-        new_instance.execution_time = source.execution_time
 
 
 class PipelineStream(_PipelineResultContainer, Iterable[PipelineResult]):

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -183,7 +183,7 @@ class _PipelineResultContainer(Generic[T]):
         elif self._explain_options is None:
             raise QueryExplainError("explain_options not set on query.")
         elif not self._started:
-            raise QueryExplainError("stream not started")
+            raise QueryExplainError("explain_stats not available until query is complete")
         else:
             raise QueryExplainError("explain_stats not found")
 

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.firestore_v1.base_pipeline import _BasePipeline
     from google.cloud.firestore_v1.pipeline import Pipeline
     from google.cloud.firestore_v1.pipeline_expressions import Constant
-    from google.cloud.firestore_v1.query_profile import ExplainOptions
+    from google.cloud.firestore_v1.query_profile import PipelineExplainOptions
 
 
 class PipelineResult:
@@ -175,7 +175,7 @@ class _PipelineResultContainer(Generic[T]):
         return_type: Type[T],
         pipeline: Pipeline | AsyncPipeline,
         transaction: Transaction | AsyncTransaction | None,
-        explain_options: ExplainOptions | None,
+        explain_options: PipelineExplainOptions | None,
         index_mode: str | None,
         additional_options: dict[str, Constant | Value],
     ):
@@ -187,7 +187,7 @@ class _PipelineResultContainer(Generic[T]):
         self._client: Client | AsyncClient = pipeline._client
         self._started: bool = False
         self._explain_stats: ExplainStats | None = None
-        self._explain_options: ExplainOptions | None = explain_options
+        self._explain_options: PipelineExplainOptions | None = explain_options
         self._return_type = return_type
         self._index_mode = index_mode
         self._additonal_options = {

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -185,7 +185,7 @@ class _PipelineResultContainer(Generic[T]):
         elif not self._started:
             raise QueryExplainError("stream not started")
         else:
-            raise QueryExplainError("explain_options not found")
+            raise QueryExplainError("explain_stats not found")
 
     def _build_request(self) -> ExecutePipelineRequest:
         """
@@ -265,5 +265,5 @@ class AsyncPipelineStream(_PipelineResultContainer[T], AsyncIterable[T]):
         request = self._build_request()
         stream = await self._client._firestore_api.execute_pipeline(request)
         async for response in stream:
-            for response in self._process_response(response):
-                yield response
+            for result in self._process_response(response):
+                yield result

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -168,7 +168,7 @@ T = TypeVar("T", bound=PipelineResult)
 
 
 class _PipelineResultContainer(Generic[T]):
-    """Helper to hold shared attributes for PipelineSnapshot and PipelineStream"""
+    """Base class to hold shared attributes for PipelineSnapshot and PipelineStream"""
 
     def __init__(
         self,

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -233,7 +233,7 @@ class PipelineSnapshot(_PipelineResultContainer[T], list[T]):
     A list type that holds the result of a pipeline.execute() operation, along with related metadata
     """
     def __init__(self, results_list: list[T], source: _PipelineResultContainer[T]):
-        self.__dict__.update(copy.deepcopy(source.__dict__))
+        self.__dict__.update(source.__dict__.copy())
         list.__init__(self, results_list)
         # snapshots are always complete
         self._started = True

--- a/google/cloud/firestore_v1/query_profile.py
+++ b/google/cloud/firestore_v1/query_profile.py
@@ -21,8 +21,11 @@ from dataclasses import dataclass
 from google.protobuf.json_format import MessageToDict
 from google.cloud.firestore_v1.types.document import MapValue
 from google.cloud.firestore_v1.types.document import Value
-from google.cloud.firestore_v1.types.explain_stats import ExplainStats as ExplainStats_pb
+from google.cloud.firestore_v1.types.explain_stats import (
+    ExplainStats as ExplainStats_pb,
+)
 from google.protobuf.wrappers_pb2 import StringValue
+
 
 @dataclass(frozen=True)
 class ExplainOptions:
@@ -151,6 +154,7 @@ class QueryExplainError(Exception):
     """
 
     pass
+
 
 class ExplainStats:
     """

--- a/google/cloud/firestore_v1/query_profile.py
+++ b/google/cloud/firestore_v1/query_profile.py
@@ -19,6 +19,8 @@ import datetime
 
 from dataclasses import dataclass
 from google.protobuf.json_format import MessageToDict
+from google.cloud.firestore_v1.types.document import MapValue
+from google.cloud.firestore_v1.types.document import Value
 
 
 @dataclass(frozen=True)
@@ -40,6 +42,11 @@ class ExplainOptions:
 
     def _to_dict(self):
         return {"analyze": self.analyze}
+
+    def _to_value(self):
+        mode_str = "analyze" if self.analyze else "explain"
+        value_pb = MapValue(fields={"mode": Value(string_value=mode_str)})
+        return Value(map_value=value_pb)
 
 
 @dataclass(frozen=True)

--- a/google/cloud/firestore_v1/query_profile.py
+++ b/google/cloud/firestore_v1/query_profile.py
@@ -176,13 +176,17 @@ class ExplainStats:
 
     def get_text(self) -> str:
         """
-        Returns the explain stats string verbatim as returned from the Firestore backend.
+        Returns the explain stats as a string.
+
+        This method is suitable for explain formats that have a text-based output,
+        such as 'text' or 'json'.
 
         Returns:
-            str: the string representation of the explain_stats object
+            str: The string representation of the explain stats.
 
         Raises:
-            QueryExplainError: If the explain stats cannot be parsed.
+            QueryExplainError: If the explain stats payload from the backend is not
+                a string. This can happen if a non-text output format was requested.
         """
         pb_data = self._stats_pb._pb.data
         content = StringValue()

--- a/google/cloud/firestore_v1/query_profile.py
+++ b/google/cloud/firestore_v1/query_profile.py
@@ -47,9 +47,30 @@ class ExplainOptions:
     def _to_dict(self):
         return {"analyze": self.analyze}
 
+
+@dataclass(frozen=True)
+class PipelineExplainOptions:
+    """
+    Explain options for pipeline queries.
+
+    Set on a pipeline.execution() or pipeline.stream() call, to provide
+    explain_stats in the pipeline output
+
+    :type mode: str
+    :param mode: Optional. The mode of operation for this explain query.
+        When set to 'analyze', the query will be executed and return the full
+        query results along with execution statistics.
+
+    :type output_format: str | None
+    :param output_format: Optional. The format in which to return the explain
+        stats.
+    """
+
+    mode: str = "analyze"
+
     def _to_value(self):
-        mode_str = "analyze" if self.analyze else "explain"
-        value_pb = MapValue(fields={"mode": Value(string_value=mode_str)})
+        out_dict = {"mode": Value(string_value=self.mode)}
+        value_pb = MapValue(fields=out_dict)
         return Value(map_value=value_pb)
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1660,7 +1660,7 @@ def test_query_stream_or_get_w_explain_options_analyze_false(
 def test_pipeline_explain_options_explain_mode(database, method, query_docs):
     """Explain currently not supported by backend. Expect error"""
     from google.cloud.firestore_v1.query_profile import (
-        ExplainOptions,
+        PipelineExplainOptions,
     )
 
     collection, _, _ = query_docs
@@ -1668,7 +1668,7 @@ def test_pipeline_explain_options_explain_mode(database, method, query_docs):
 
     # Tests either `execute()` or `stream()`.
     method_under_test = getattr(pipeline, method)
-    explain_options = ExplainOptions(analyze=False)
+    explain_options = PipelineExplainOptions(mode="explain")
 
     # for now, expect error on explain mode
     with pytest.raises(InvalidArgument) as e:
@@ -1684,7 +1684,7 @@ def test_pipeline_explain_options_explain_mode(database, method, query_docs):
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
 def test_pipeline_explain_options_analyze_mode(database, method, query_docs):
     from google.cloud.firestore_v1.query_profile import (
-        ExplainOptions,
+        PipelineExplainOptions,
         ExplainStats,
         QueryExplainError,
     )
@@ -1697,7 +1697,7 @@ def test_pipeline_explain_options_analyze_mode(database, method, query_docs):
 
     # Tests either `execute()` or `stream()`.
     method_under_test = getattr(pipeline, method)
-    results = method_under_test(explain_options=ExplainOptions(analyze=True))
+    results = method_under_test(explain_options=PipelineExplainOptions())
 
     if method == "stream":
         # check for error accessing explain stats before iterating
@@ -1731,7 +1731,7 @@ def test_pipeline_explain_options_using_additional_options(
 ):
     """additional_options field allows passing in arbitrary options. Test with explain_options"""
     from google.cloud.firestore_v1.query_profile import (
-        ExplainOptions,
+        PipelineExplainOptions,
         ExplainStats,
     )
     from google.cloud.firestore_v1.types.explain_stats import (
@@ -1744,7 +1744,7 @@ def test_pipeline_explain_options_using_additional_options(
     # Tests either `execute()` or `stream()`.
     method_under_test = getattr(pipeline, method)
 
-    encoded_options = {"explain_options": ExplainOptions(analyze=True)._to_value()}
+    encoded_options = {"explain_options": PipelineExplainOptions()._to_value()}
 
     results = method_under_test(
         explain_options=mock.Mock(), additional_options=encoded_options

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1657,13 +1657,10 @@ def test_query_stream_or_get_w_explain_options_analyze_false(
 )
 @pytest.mark.parametrize("method", ["execute", "stream"])
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
-def test_pipeline_explain_options_explain_mode(
-    database, method, query_docs
-):
+def test_pipeline_explain_options_explain_mode(database, method, query_docs):
     """Explain currently not supported by backend. Expect error"""
     from google.cloud.firestore_v1.query_profile import (
         ExplainOptions,
-        ExplainStats,
     )
 
     collection, _, _ = query_docs
@@ -1677,7 +1674,7 @@ def test_pipeline_explain_options_explain_mode(
     with pytest.raises(InvalidArgument) as e:
         results = method_under_test(explain_options=explain_options)
         list(results)
-    assert"Explain execution mode is not supported" in str(e)
+    assert "Explain execution mode is not supported" in str(e)
 
 
 @pytest.mark.skipif(
@@ -1685,15 +1682,15 @@ def test_pipeline_explain_options_explain_mode(
 )
 @pytest.mark.parametrize("method", ["execute", "stream"])
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
-def test_pipeline_explain_options_analyze_mode(
-    database, method, query_docs
-):
+def test_pipeline_explain_options_analyze_mode(database, method, query_docs):
     from google.cloud.firestore_v1.query_profile import (
         ExplainOptions,
         ExplainStats,
         QueryExplainError,
     )
-    from google.cloud.firestore_v1.types.explain_stats import ExplainStats as ExplainStats_pb
+    from google.cloud.firestore_v1.types.explain_stats import (
+        ExplainStats as ExplainStats_pb,
+    )
 
     collection, _, allowed_vals = query_docs
     pipeline = collection.where(filter=FieldFilter("a", "==", 1)).pipeline()
@@ -1736,9 +1733,10 @@ def test_pipeline_explain_options_using_additional_options(
     from google.cloud.firestore_v1.query_profile import (
         ExplainOptions,
         ExplainStats,
-        QueryExplainError,
     )
-    from google.cloud.firestore_v1.types.explain_stats import ExplainStats as ExplainStats_pb
+    from google.cloud.firestore_v1.types.explain_stats import (
+        ExplainStats as ExplainStats_pb,
+    )
 
     collection, _, allowed_vals = query_docs
     pipeline = collection.where(filter=FieldFilter("a", "==", 1)).pipeline()
@@ -1748,7 +1746,9 @@ def test_pipeline_explain_options_using_additional_options(
 
     encoded_options = {"explain_options": ExplainOptions(analyze=True)._to_value()}
 
-    results = method_under_test(explain_options=mock.Mock(), additional_options=encoded_options)
+    results = method_under_test(
+        explain_options=mock.Mock(), additional_options=encoded_options
+    )
 
     # Finish iterating results, and explain_stats should be available.
     results_list = list(results)
@@ -1763,13 +1763,12 @@ def test_pipeline_explain_options_using_additional_options(
     text_stats = explain_stats.get_text()
     assert "Execution:" in text_stats
 
+
 @pytest.mark.skipif(
     FIRESTORE_EMULATOR, reason="Query profile not supported in emulator."
 )
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
-def test_pipeline_index_mode(
-    database, query_docs
-):
+def test_pipeline_index_mode(database, query_docs):
     """test pipeline query with explicit index mode"""
 
     collection, _, allowed_vals = query_docs

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1578,9 +1578,7 @@ async def test_query_stream_or_get_w_explain_options_analyze_false(
 )
 @pytest.mark.parametrize("method", ["execute", "stream"])
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
-async def test_pipeline_explain_options_explain_mode(
-    database, method, query_docs
-):
+async def test_pipeline_explain_options_explain_mode(database, method, query_docs):
     """Explain currently not supported by backend. Expect error"""
     from google.api_core.exceptions import InvalidArgument
     from google.cloud.firestore_v1.query_profile import (
@@ -1608,9 +1606,7 @@ async def test_pipeline_explain_options_explain_mode(
 )
 @pytest.mark.parametrize("method", ["execute", "stream"])
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
-async def test_pipeline_explain_options_analyze_mode(
-    database, method, query_docs
-):
+async def test_pipeline_explain_options_analyze_mode(database, method, query_docs):
     from google.cloud.firestore_v1.query_profile import (
         ExplainOptions,
         ExplainStats,
@@ -1648,6 +1644,7 @@ async def test_pipeline_explain_options_analyze_mode(
     text_stats = explain_stats.get_text()
     assert "Execution:" in text_stats
 
+
 @pytest.mark.skipif(
     FIRESTORE_EMULATOR, reason="Query profile not supported in emulator."
 )
@@ -1660,7 +1657,6 @@ async def test_pipeline_explain_options_using_additional_options(
     from google.cloud.firestore_v1.query_profile import (
         ExplainOptions,
         ExplainStats,
-        QueryExplainError,
     )
     from google.cloud.firestore_v1.types.explain_stats import (
         ExplainStats as ExplainStats_pb,
@@ -1672,7 +1668,9 @@ async def test_pipeline_explain_options_using_additional_options(
     method_under_test = getattr(pipeline, method)
     encoded_options = {"explain_options": ExplainOptions(analyze=True)._to_value()}
 
-    stub = method_under_test(explain_options=mock.Mock(), additional_options=encoded_options)
+    stub = method_under_test(
+        explain_options=mock.Mock(), additional_options=encoded_options
+    )
     if method == "execute":
         results = await stub
         num_results = len(results)

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -1582,14 +1582,14 @@ async def test_pipeline_explain_options_explain_mode(database, method, query_doc
     """Explain currently not supported by backend. Expect error"""
     from google.api_core.exceptions import InvalidArgument
     from google.cloud.firestore_v1.query_profile import (
-        ExplainOptions,
+        PipelineExplainOptions,
     )
 
     collection, _, _ = query_docs
     pipeline = collection.where(filter=FieldFilter("a", "==", 1)).pipeline()
 
     method_under_test = getattr(pipeline, method)
-    explain_options = ExplainOptions(analyze=False)
+    explain_options = PipelineExplainOptions(mode="explain")
 
     with pytest.raises(InvalidArgument) as e:
         if method == "stream":
@@ -1608,7 +1608,7 @@ async def test_pipeline_explain_options_explain_mode(database, method, query_doc
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
 async def test_pipeline_explain_options_analyze_mode(database, method, query_docs):
     from google.cloud.firestore_v1.query_profile import (
-        ExplainOptions,
+        PipelineExplainOptions,
         ExplainStats,
         QueryExplainError,
     )
@@ -1620,7 +1620,7 @@ async def test_pipeline_explain_options_analyze_mode(database, method, query_doc
     pipeline = collection.where(filter=FieldFilter("a", "==", 1)).pipeline()
 
     method_under_test = getattr(pipeline, method)
-    explain_options = ExplainOptions(analyze=True)
+    explain_options = PipelineExplainOptions()
 
     if method == "execute":
         results = await method_under_test(explain_options=explain_options)
@@ -1655,7 +1655,7 @@ async def test_pipeline_explain_options_using_additional_options(
 ):
     """additional_options field allows passing in arbitrary options. Test with explain_options"""
     from google.cloud.firestore_v1.query_profile import (
-        ExplainOptions,
+        PipelineExplainOptions,
         ExplainStats,
     )
     from google.cloud.firestore_v1.types.explain_stats import (
@@ -1666,7 +1666,7 @@ async def test_pipeline_explain_options_using_additional_options(
     pipeline = collection.where(filter=FieldFilter("a", "==", 1)).pipeline()
 
     method_under_test = getattr(pipeline, method)
-    encoded_options = {"explain_options": ExplainOptions(analyze=True)._to_value()}
+    encoded_options = {"explain_options": PipelineExplainOptions()._to_value()}
 
     stub = method_under_test(
         explain_options=mock.Mock(), additional_options=encoded_options

--- a/tests/unit/v1/test_async_pipeline.py
+++ b/tests/unit/v1/test_async_pipeline.py
@@ -359,24 +359,6 @@ async def test_async_pipeline_stream_stream_equivalence():
     assert stream_results[0].data()["key"] == "str_val"
 
 
-@pytest.mark.asyncio
-async def test_async_pipeline_stream_stream_equivalence_mocked():
-    """
-    pipeline.stream should call pipeline.stream internally
-    """
-    ppl_1 = _make_async_pipeline()
-    expected_data = [object(), object()]
-    expected_arg = object()
-    with mock.patch.object(ppl_1, "stream") as mock_stream:
-        mock_stream.return_value = _async_it(expected_data)
-        stream_results = await ppl_1.execute(expected_arg)
-        assert mock_stream.call_count == 1
-        assert mock_stream.call_args[0] == ()
-        assert len(mock_stream.call_args[1]) == 1
-        assert mock_stream.call_args[1]["transaction"] == expected_arg
-        assert stream_results == expected_data
-
-
 @pytest.mark.parametrize(
     "method,args,result_cls",
     [

--- a/tests/unit/v1/test_pipeline.py
+++ b/tests/unit/v1/test_pipeline.py
@@ -107,7 +107,6 @@ def test_pipeline__to_pb_with_options():
     assert pb.options["option_1"].integer_value == 1
 
 
-
 def test_pipeline_append():
     """append should create a new pipeline with the additional stage"""
 

--- a/tests/unit/v1/test_pipeline.py
+++ b/tests/unit/v1/test_pipeline.py
@@ -96,6 +96,18 @@ def test_pipeline__to_pb():
     assert pb.pipeline.stages[1] == stage_2._to_pb()
 
 
+def test_pipeline__to_pb_with_options():
+    from google.cloud.firestore_v1.types.pipeline import StructuredPipeline
+    from google.cloud.firestore_v1.types.document import Value
+
+    ppl = _make_pipeline()
+    options = {"option_1": Value(integer_value=1)}
+    pb = ppl._to_pb(**options)
+    assert isinstance(pb, StructuredPipeline)
+    assert pb.options["option_1"].integer_value == 1
+
+
+
 def test_pipeline_append():
     """append should create a new pipeline with the additional stage"""
 
@@ -335,23 +347,6 @@ def test_pipeline_execute_stream_equivalence():
     assert stream_results == execute_results
     assert stream_results[0].data()["key"] == "str_val"
     assert execute_results[0].data()["key"] == "str_val"
-
-
-def test_pipeline_execute_stream_equivalence_mocked():
-    """
-    pipeline.execute should call pipeline.stream internally
-    """
-    ppl_1 = _make_pipeline()
-    expected_data = [object(), object()]
-    expected_arg = object()
-    with mock.patch.object(ppl_1, "stream") as mock_stream:
-        mock_stream.return_value = expected_data
-        stream_results = ppl_1.execute(expected_arg)
-        assert mock_stream.call_count == 1
-        assert mock_stream.call_args[0] == ()
-        assert len(mock_stream.call_args[1]) == 1
-        assert mock_stream.call_args[1]["transaction"] == expected_arg
-        assert stream_results == expected_data
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/v1/test_pipeline_result.py
+++ b/tests/unit/v1/test_pipeline_result.py
@@ -32,6 +32,7 @@ _mock_stream_responses = [
     ExecutePipelineResponse(
         results=[Document(name="projects/p/databases/d/documents/c/d1", fields={})],
         execution_time=Timestamp(seconds=1, nanos=2),
+        explain_stats={"data": {}},
     ),
     ExecutePipelineResponse(
         results=[Document(name="projects/p/databases/d/documents/c/d2", fields={})],
@@ -431,6 +432,10 @@ class TestPipelineStream(SharedStreamTests):
         assert instance.execution_time.seconds == 1
         assert instance.execution_time.nanos == 2
 
+        # expect empty stats
+        got_stats = instance.explain_stats.get_raw().data
+        assert got_stats.value == b""
+
         instance._client._firestore_api.execute_pipeline.assert_called_once()
 
     def test_double_iterate(self):
@@ -478,6 +483,10 @@ class TestAsyncPipelineStream(SharedStreamTests):
 
         assert instance.execution_time.seconds == 1
         assert instance.execution_time.nanos == 2
+
+        # expect empty stats
+        got_stats = instance.explain_stats.get_raw().data
+        assert got_stats.value == b""
 
         instance._client._firestore_api.execute_pipeline.assert_called_once()
 

--- a/tests/unit/v1/test_pipeline_result.py
+++ b/tests/unit/v1/test_pipeline_result.py
@@ -22,7 +22,7 @@ from google.cloud.firestore_v1.pipeline_result import PipelineSnapshot
 from google.cloud.firestore_v1.pipeline_result import PipelineStream
 from google.cloud.firestore_v1.pipeline_result import AsyncPipelineStream
 from google.cloud.firestore_v1.query_profile import QueryExplainError
-from google.cloud.firestore_v1.query_profile import ExplainOptions
+from google.cloud.firestore_v1.query_profile import PipelineExplainOptions
 from google.cloud.firestore_v1._helpers import encode_value
 from google.cloud.firestore_v1.types.document import Document
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -295,11 +295,11 @@ class SharedStreamTests:
         [
             ({"index_mode": "mode"}, {"index_mode": encode_value("mode")}),
             (
-                {"explain_options": ExplainOptions(analyze=True)},
+                {"explain_options": PipelineExplainOptions()},
                 {"explain_options": encode_value({"mode": "analyze"})},
             ),
             (
-                {"explain_options": ExplainOptions(analyze=False)},
+                {"explain_options": PipelineExplainOptions(mode="explain")},
                 {"explain_options": encode_value({"mode": "explain"})},
             ),
             (
@@ -312,7 +312,7 @@ class SharedStreamTests:
             ),
             (
                 {
-                    "explain_options": ExplainOptions(),
+                    "explain_options": PipelineExplainOptions(),
                     "additional_options": {"explain_options": Constant.of("override")},
                 },
                 {"explain_options": encode_value("override")},

--- a/tests/unit/v1/test_pipeline_result.py
+++ b/tests/unit/v1/test_pipeline_result.py
@@ -277,7 +277,7 @@ class TestPipelineStream:
         instance._started = False
         with pytest.raises(QueryExplainError) as e:
             instance.explain_stats
-        assert "stream not started" in str(e)
+        assert "not available until query is complete" in str(e)
 
     def test_iter(self):
         pipeline = mock.Mock()
@@ -344,7 +344,7 @@ class TestAsyncPipelineStream:
         instance._started = False
         with pytest.raises(QueryExplainError) as e:
             instance.explain_stats
-        assert "stream not started" in str(e)
+        assert "not available until query is complete" in str(e)
 
     @pytest.mark.asyncio
     async def test_aiter(self):

--- a/tests/unit/v1/test_query_profile.py
+++ b/tests/unit/v1/test_query_profile.py
@@ -125,9 +125,10 @@ def test_explain_options__to_dict():
     assert ExplainOptions(analyze=True)._to_dict() == {"analyze": True}
     assert ExplainOptions(analyze=False)._to_dict() == {"analyze": False}
 
-@pytest.mark.parametrize("analyze_bool,expected_str", [
-    (True, "analyze"), (False, "explain")
-])
+
+@pytest.mark.parametrize(
+    "analyze_bool,expected_str", [(True, "analyze"), (False, "explain")]
+)
 def test_explain_options__to_value(analyze_bool, expected_str):
     """
     Should be able to create a Value protobuf representation of ExplainOptions
@@ -180,8 +181,6 @@ def test_explain_stats_get_text_error():
         QueryExplainError,
     )
     from google.cloud.firestore_v1.types import explain_stats as explain_stats_pb2
-    from google.cloud.firestore_v1.types import document
-    from google.protobuf import any_pb2
 
     expected_stats_pb = explain_stats_pb2.ExplainStats(data={})
     stats = ExplainStats(expected_stats_pb)

--- a/tests/unit/v1/test_query_profile.py
+++ b/tests/unit/v1/test_query_profile.py
@@ -124,3 +124,67 @@ def test_explain_options__to_dict():
 
     assert ExplainOptions(analyze=True)._to_dict() == {"analyze": True}
     assert ExplainOptions(analyze=False)._to_dict() == {"analyze": False}
+
+@pytest.mark.parametrize("analyze_bool,expected_str", [
+    (True, "analyze"), (False, "explain")
+])
+def test_explain_options__to_value(analyze_bool, expected_str):
+    """
+    Should be able to create a Value protobuf representation of ExplainOptions
+    """
+    from google.cloud.firestore_v1.query_profile import ExplainOptions
+    from google.cloud.firestore_v1.types.document import MapValue
+    from google.cloud.firestore_v1.types.document import Value
+
+    options = ExplainOptions(analyze=analyze_bool)
+    expected_value = Value(
+        map_value=MapValue(fields={"mode": Value(string_value=expected_str)})
+    )
+    assert options._to_value() == expected_value
+
+
+def test_explain_stats_get_raw():
+    """
+    Test ExplainStats.get_raw(). Should return input directly
+    """
+    from google.cloud.firestore_v1.query_profile import ExplainStats
+
+    input = object()
+    stats = ExplainStats(input)
+    assert stats.get_raw() is input
+
+
+def test_explain_stats_get_text():
+    """
+    Test ExplainStats.get_text()
+    """
+    from google.cloud.firestore_v1.query_profile import ExplainStats
+    from google.cloud.firestore_v1.types import explain_stats as explain_stats_pb2
+    from google.protobuf import any_pb2
+    from google.protobuf import wrappers_pb2
+
+    expected_text = "some text"
+    text_pb = any_pb2.Any()
+    text_pb.Pack(wrappers_pb2.StringValue(value=expected_text))
+    expected_stats_pb = explain_stats_pb2.ExplainStats(data=text_pb)
+    stats = ExplainStats(expected_stats_pb)
+    assert stats.get_text() == expected_text
+
+
+def test_explain_stats_get_text_error():
+    """
+    Test ExplainStats.get_text() raises QueryExplainError
+    """
+    from google.cloud.firestore_v1.query_profile import (
+        ExplainStats,
+        QueryExplainError,
+    )
+    from google.cloud.firestore_v1.types import explain_stats as explain_stats_pb2
+    from google.cloud.firestore_v1.types import document
+    from google.protobuf import any_pb2
+
+    expected_stats_pb = explain_stats_pb2.ExplainStats(data={})
+    stats = ExplainStats(expected_stats_pb)
+    with pytest.raises(QueryExplainError) as exc:
+        stats.get_text()
+    assert "Unable to decode explain stats" in str(exc.value)

--- a/tests/unit/v1/test_query_profile.py
+++ b/tests/unit/v1/test_query_profile.py
@@ -126,20 +126,18 @@ def test_explain_options__to_dict():
     assert ExplainOptions(analyze=False)._to_dict() == {"analyze": False}
 
 
-@pytest.mark.parametrize(
-    "analyze_bool,expected_str", [(True, "analyze"), (False, "explain")]
-)
-def test_explain_options__to_value(analyze_bool, expected_str):
+@pytest.mark.parametrize("mode_str", ["analyze", "explain"])
+def test_pipeline_explain_options__to_value(mode_str):
     """
     Should be able to create a Value protobuf representation of ExplainOptions
     """
-    from google.cloud.firestore_v1.query_profile import ExplainOptions
+    from google.cloud.firestore_v1.query_profile import PipelineExplainOptions
     from google.cloud.firestore_v1.types.document import MapValue
     from google.cloud.firestore_v1.types.document import Value
 
-    options = ExplainOptions(analyze=analyze_bool)
+    options = PipelineExplainOptions(mode=mode_str)
     expected_value = Value(
-        map_value=MapValue(fields={"mode": Value(string_value=expected_str)})
+        map_value=MapValue(fields={"mode": Value(string_value=mode_str)})
     )
     assert options._to_value() == expected_value
 


### PR DESCRIPTION
This PR adds explain_stats to pipelines, and supports passing in index_mode and other generic pipeline options.

To support this, I added new PipelineSnapshot, PipelineStream, and AsyncPipelineStream classes to wrap the original list and generators returned by pipeline execution operations. These classes still act like the base classes they replace, but also add custom getters for pipeline metadata, like `ExplainStats`