### PR TITLE
chore: librarian release pull request: 20251114T184924Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:ce48ed695c727f7e13efd1fd68f466a55a0d772c87b69158720cec39965bc8b2
 libraries:
   - id: google-cloud-firestore
-    version: 2.21.0
+    version: 2.22.0
     last_generated_commit: 659ea6e98acc7d58661ce2aa7b4cf76a7ef3fd42
     apis:
       - path: google/firestore/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 [1]: https://pypi.org/project/google-cloud-firestore/#history
 
+## [2.22.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-firestore-v2.21.0...google-cloud-firestore-v2.22.0) (2025-11-14)
+
+
+### Features
+
+* Add support for Python 3.14 (#1110) ([52b2055d01ab5d2c34e00f8861e29990f89cd3d8](https://github.com/googleapis/google-cloud-python/commit/52b2055d01ab5d2c34e00f8861e29990f89cd3d8))
+* Expose tags field in Database and RestoreDatabaseRequest public protos (#1074) ([49836391dc712bd482781a26ccd3c8a8408c473b](https://github.com/googleapis/google-cloud-python/commit/49836391dc712bd482781a26ccd3c8a8408c473b))
+* Added read_time as a parameter to various calls (synchronous/base classes) (#1050) ([d8e3af1f9dbdfaf5df0d993a0a7e28883472c621](https://github.com/googleapis/google-cloud-python/commit/d8e3af1f9dbdfaf5df0d993a0a7e28883472c621))
+
+
+### Bug Fixes
+
+* update the async transactional types (#1066) ([210a14a4b758d70aad05940665ed2a2a21ae2a8b](https://github.com/googleapis/google-cloud-python/commit/210a14a4b758d70aad05940665ed2a2a21ae2a8b))
+
 
 ## [2.21.0](https://github.com/googleapis/python-firestore/compare/v2.20.2...v2.21.0) (2025-05-23)
 

--- a/google/cloud/firestore/gapic_version.py
+++ b/google/cloud/firestore/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/firestore_admin_v1/gapic_version.py
+++ b/google/cloud/firestore_admin_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/firestore_bundle/gapic_version.py
+++ b/google/cloud/firestore_bundle/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/firestore_v1/gapic_version.py
+++ b/google/cloud/firestore_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.6.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:ce48ed695c727f7e13efd1fd68f466a55a0d772c87b69158720cec39965bc8b2
<details><summary>google-cloud-firestore: 2.22.0</summary>

## [2.22.0](https://github.com/googleapis/python-firestore/compare/v2.21.0...v2.22.0) (2025-11-14)

### Features

* Expose tags field in Database and RestoreDatabaseRequest public protos (#1074) ([49836391](https://github.com/googleapis/python-firestore/commit/49836391))

* Add support for Python 3.14 (#1110) ([52b2055d](https://github.com/googleapis/python-firestore/commit/52b2055d))

* Added read_time as a parameter to various calls (synchronous/base classes) (#1050) ([d8e3af1f](https://github.com/googleapis/python-firestore/commit/d8e3af1f))

### Bug Fixes

* update the async transactional types (#1066) ([210a14a4](https://github.com/googleapis/python-firestore/commit/210a14a4))

</details>