### PR TITLE
chore: librarian release pull request: 20251216T095233Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:eec191fc4904c204cd717c79812cd66997b5559776483ee223f69c8f43e99224
 libraries:
   - id: google-cloud-firestore
-    version: 2.21.0
+    version: 2.22.0
     last_generated_commit: 659ea6e98acc7d58661ce2aa7b4cf76a7ef3fd42
     apis:
       - path: google/firestore/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 [1]: https://pypi.org/project/google-cloud-firestore/#history
 
+## [2.22.0](https://github.com/googleapis/python-firestore/compare/v2.21.0...v2.22.0) (2025-12-16)
+
+
+### Features
+
+* support mTLS certificates when available (#1140) ([403afb08109c8271eddd97d6172136271cc0a8a9](https://github.com/googleapis/python-firestore/commit/403afb08109c8271eddd97d6172136271cc0a8a9))
+* Add support for Python 3.14 (#1110) ([52b2055d01ab5d2c34e00f8861e29990f89cd3d8](https://github.com/googleapis/python-firestore/commit/52b2055d01ab5d2c34e00f8861e29990f89cd3d8))
+* Expose tags field in Database and RestoreDatabaseRequest public protos (#1074) ([49836391dc712bd482781a26ccd3c8a8408c473b](https://github.com/googleapis/python-firestore/commit/49836391dc712bd482781a26ccd3c8a8408c473b))
+* Added read_time as a parameter to various calls (synchronous/base classes) (#1050) ([d8e3af1f9dbdfaf5df0d993a0a7e28883472c621](https://github.com/googleapis/python-firestore/commit/d8e3af1f9dbdfaf5df0d993a0a7e28883472c621))
+
+
+### Bug Fixes
+
+* improve typing (#1136) ([d1c730d9eef867d16d7818a75f7d58439a942c1d](https://github.com/googleapis/python-firestore/commit/d1c730d9eef867d16d7818a75f7d58439a942c1d))
+* update the async transactional types (#1066) ([210a14a4b758d70aad05940665ed2a2a21ae2a8b](https://github.com/googleapis/python-firestore/commit/210a14a4b758d70aad05940665ed2a2a21ae2a8b))
+
 
 ## [2.21.0](https://github.com/googleapis/python-firestore/compare/v2.20.2...v2.21.0) (2025-05-23)
 

--- a/google/cloud/firestore/gapic_version.py
+++ b/google/cloud/firestore/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/firestore_admin_v1/gapic_version.py
+++ b/google/cloud/firestore_admin_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/firestore_bundle/gapic_version.py
+++ b/google/cloud/firestore_bundle/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}

--- a/google/cloud/firestore_v1/gapic_version.py
+++ b/google/cloud/firestore_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "2.21.0"  # {x-release-please-version}
+__version__ = "2.22.0"  # {x-release-please-version}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:eec191fc4904c204cd717c79812cd66997b5559776483ee223f69c8f43e99224
<details><summary>google-cloud-firestore: 2.22.0</summary>

## [2.22.0](https://github.com/googleapis/python-firestore/compare/v2.21.0...v2.22.0) (2025-12-16)

### Features

* support mTLS certificates when available (#1140) ([403afb08](https://github.com/googleapis/python-firestore/commit/403afb08))

* Expose tags field in Database and RestoreDatabaseRequest public protos (#1074) ([49836391](https://github.com/googleapis/python-firestore/commit/49836391))

* Add support for Python 3.14 (#1110) ([52b2055d](https://github.com/googleapis/python-firestore/commit/52b2055d))

* Added read_time as a parameter to various calls (synchronous/base classes) (#1050) ([d8e3af1f](https://github.com/googleapis/python-firestore/commit/d8e3af1f))

### Bug Fixes

* update the async transactional types (#1066) ([210a14a4](https://github.com/googleapis/python-firestore/commit/210a14a4))

* improve typing (#1136) ([d1c730d9](https://github.com/googleapis/python-firestore/commit/d1c730d9))

</details>