### PR TITLE
chore: update ignored warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,4 @@ filterwarnings =
     ignore:.*\'asyncio.iscoroutinefunction\' is deprecated.*:DeprecationWarning
     ignore:.*\'asyncio.get_event_loop_policy\' is deprecated.*:DeprecationWarning
     ignore:.*Please upgrade to the latest Python version.*:FutureWarning
+    ignore:(?s).*using a Python version.*past its end of life.*:FutureWarning


### PR DESCRIPTION
The new 3.9 upgrade warning has a different format, so it needs to be added to filter
