### PR TITLE
chore(tests): re-enable pipeline system tests on kokoro

### DIFF
--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -68,7 +68,6 @@ class AsyncPipeline(_BasePipeline):
         transaction: "AsyncTransaction" | None = None,
         read_time: datetime.datetime | None = None,
         explain_options: PipelineExplainOptions | None = None,
-        index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineSnapshot[PipelineResult]:
         """
@@ -87,10 +86,8 @@ class AsyncPipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
-            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
-                Firestore will reject the request if there is not appropiate indexes to serve the query.
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
-                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options)
         """
         kwargs = {k: v for k, v in locals().items() if k != "self"}
         stream = AsyncPipelineStream(PipelineResult, self, **kwargs)
@@ -103,7 +100,6 @@ class AsyncPipeline(_BasePipeline):
         read_time: datetime.datetime | None = None,
         transaction: "AsyncTransaction" | None = None,
         explain_options: PipelineExplainOptions | None = None,
-        index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> AsyncPipelineStream[PipelineResult]:
         """
@@ -122,10 +118,8 @@ class AsyncPipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
-            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
-                Firestore will reject the request if there is not appropiate indexes to serve the query.
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
-                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options)
         """
         kwargs = {k: v for k, v in locals().items() if k != "self"}
         return AsyncPipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -65,7 +65,6 @@ class Pipeline(_BasePipeline):
         transaction: "Transaction" | None = None,
         read_time: datetime.datetime | None = None,
         explain_options: PipelineExplainOptions | None = None,
-        index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineSnapshot[PipelineResult]:
         """
@@ -84,10 +83,8 @@ class Pipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned list.
-            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
-                Firestore will reject the request if there is not appropiate indexes to serve the query.
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
-                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options)
         """
         kwargs = {k: v for k, v in locals().items() if k != "self"}
         stream = PipelineStream(PipelineResult, self, **kwargs)
@@ -100,7 +97,6 @@ class Pipeline(_BasePipeline):
         transaction: "Transaction" | None = None,
         read_time: datetime.datetime | None = None,
         explain_options: PipelineExplainOptions | None = None,
-        index_mode: str | None = None,
         additional_options: dict[str, Value | Constant] = {},
     ) -> PipelineStream[PipelineResult]:
         """
@@ -119,10 +115,8 @@ class Pipeline(_BasePipeline):
             explain_options (Optional[:class:`~google.cloud.firestore_v1.query_profile.PipelineExplainOptions`]):
                 Options to enable query profiling for this query. When set,
                 explain_metrics will be available on the returned generator.
-            index_mode (Optional[str]): Configures the pipeline to require a certain type of indexes to be present.
-                Firestore will reject the request if there is not appropiate indexes to serve the query.
             additional_options (Optional[dict[str, Value | Constant]]): Additional options to pass to the query.
-                These options will take precedence over method argument if there is a conflict (e.g. explain_options, index_mode)
+                These options will take precedence over method argument if there is a conflict (e.g. explain_options)
         """
         kwargs = {k: v for k, v in locals().items() if k != "self"}
         return PipelineStream(PipelineResult, self, **kwargs)

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -178,8 +178,8 @@ class _PipelineResultContainer(Generic[T]):
         transaction: Transaction | AsyncTransaction | None,
         read_time: datetime.datetime | None,
         explain_options: PipelineExplainOptions | None,
-        index_mode: str | None,
         additional_options: dict[str, Constant | Value],
+        index_mode: str | None = None,
     ):
         # public
         self.transaction = transaction

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -179,7 +179,6 @@ class _PipelineResultContainer(Generic[T]):
         read_time: datetime.datetime | None,
         explain_options: PipelineExplainOptions | None,
         additional_options: dict[str, Constant | Value],
-        index_mode: str | None = None,
     ):
         # public
         self.transaction = transaction
@@ -192,7 +191,6 @@ class _PipelineResultContainer(Generic[T]):
         self._explain_stats: ExplainStats | None = None
         self._explain_options: PipelineExplainOptions | None = explain_options
         self._return_type = return_type
-        self._index_mode = index_mode
         self._additonal_options = {
             k: v if isinstance(v, Value) else v._to_pb()
             for k, v in additional_options.items()
@@ -226,8 +224,6 @@ class _PipelineResultContainer(Generic[T]):
         options = {}
         if self._explain_options:
             options["explain_options"] = self._explain_options._to_value()
-        if self._index_mode:
-            options["index_mode"] = Value(string_value=self._index_mode)
         if self._additonal_options:
             options.update(self._additonal_options)
         request = ExecutePipelineRequest(

--- a/tests/system/test__helpers.py
+++ b/tests/system/test__helpers.py
@@ -20,5 +20,3 @@ FIRESTORE_ENTERPRISE_DB = os.environ.get("ENTERPRISE_DATABASE", "enterprise-db")
 # run all tests against default database, and a named database
 TEST_DATABASES = [None, FIRESTORE_OTHER_DB]
 TEST_DATABASES_W_ENTERPRISE = TEST_DATABASES + [FIRESTORE_ENTERPRISE_DB]
-# TODO remove when kokoro fully supports enterprise mode/pipelines
-IS_KOKORO_TEST = os.getenv("KOKORO_JOB_NAME") is not None

--- a/tests/system/test__helpers.py
+++ b/tests/system/test__helpers.py
@@ -15,7 +15,7 @@ UNIQUE_RESOURCE_ID = unique_resource_id("-")
 EMULATOR_CREDS = EmulatorCreds()
 FIRESTORE_EMULATOR = os.environ.get(_FIRESTORE_EMULATOR_HOST) is not None
 FIRESTORE_OTHER_DB = os.environ.get("SYSTEM_TESTS_DATABASE", "system-tests-named-db")
-FIRESTORE_ENTERPRISE_DB = os.environ.get("ENTERPRISE_DATABASE", "enterprise-db")
+FIRESTORE_ENTERPRISE_DB = os.environ.get("ENTERPRISE_DATABASE", "enterprise-db-native")
 
 # run all tests against default database, and a named database
 TEST_DATABASES = [None, FIRESTORE_OTHER_DB]

--- a/tests/system/test_pipeline_acceptance.py
+++ b/tests/system/test_pipeline_acceptance.py
@@ -33,15 +33,9 @@ from google.api_core.exceptions import GoogleAPIError
 
 from google.cloud.firestore import Client, AsyncClient
 
-from test__helpers import FIRESTORE_ENTERPRISE_DB, IS_KOKORO_TEST
+from test__helpers import FIRESTORE_ENTERPRISE_DB
 
 FIRESTORE_PROJECT = os.environ.get("GCLOUD_PROJECT")
-
-# TODO: enable kokoro tests when internal test project is whitelisted
-pytestmark = pytest.mark.skipif(
-    condition=IS_KOKORO_TEST,
-    reason="Pipeline tests are currently not supported by kokoro",
-)
 
 test_dir_name = os.path.dirname(__file__)
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -66,8 +66,6 @@ def _get_credentials_and_project():
 
 @pytest.fixture(scope="session")
 def database(request):
-    from test__helpers import FIRESTORE_ENTERPRISE_DB
-
     return request.param
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1759,22 +1759,6 @@ def test_pipeline_explain_options_using_additional_options(
     assert "Execution:" in text_stats
 
 
-@pytest.mark.skipif(
-    FIRESTORE_EMULATOR, reason="Query profile not supported in emulator."
-)
-@pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
-def test_pipeline_index_mode(database, query_docs):
-    """test pipeline query with explicit index mode"""
-
-    collection, _, allowed_vals = query_docs
-    client = collection._client
-    query = collection.where(filter=FieldFilter("a", "==", 1))
-    pipeline = client.pipeline().create_from(query)
-    with pytest.raises(InvalidArgument) as e:
-        pipeline.execute(index_mode="fake_index")
-    assert "Invalid index_mode: fake_index" in str(e)
-
-
 @pytest.mark.parametrize("database", TEST_DATABASES, indirect=True)
 def test_query_stream_w_read_time(query_docs, cleanup, database):
     collection, stored, allowed_vals = query_docs

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -46,7 +46,6 @@ from test__helpers import (
     ENTERPRISE_MODE_ERROR,
     TEST_DATABASES,
     TEST_DATABASES_W_ENTERPRISE,
-    IS_KOKORO_TEST,
     FIRESTORE_ENTERPRISE_DB,
 )
 
@@ -69,10 +68,6 @@ def _get_credentials_and_project():
 def database(request):
     from test__helpers import FIRESTORE_ENTERPRISE_DB
 
-    # enterprise mode currently does not support RunQuery calls in prod on kokoro test project
-    # TODO: remove skip when kokoro test project supports full enterprise mode
-    if request.param == FIRESTORE_ENTERPRISE_DB and IS_KOKORO_TEST:
-        pytest.skip("enterprise mode does not support RunQuery on kokoro")
     return request.param
 
 
@@ -100,11 +95,6 @@ def verify_pipeline(query):
     modalities at the same time
     """
     from google.cloud.firestore_v1.base_aggregation import BaseAggregationQuery
-
-    # return early on kokoro. Test project doesn't currently support pipelines
-    # TODO: enable pipeline verification when kokoro test project is whitelisted
-    if IS_KOKORO_TEST:
-        pytest.skip("skipping pipeline verification on kokoro")
 
     def _clean_results(results):
         if isinstance(results, dict):
@@ -1825,7 +1815,6 @@ def test_query_stream_w_read_time(query_docs, cleanup, database):
     assert new_values[new_ref.id] == new_data
 
 
-@pytest.mark.skipif(IS_KOKORO_TEST, reason="skipping pipeline verification on kokoro")
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
 def test_pipeline_w_read_time(query_docs, cleanup, database):
     collection, stored, allowed_vals = query_docs

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -57,7 +57,6 @@ from test__helpers import (
     ENTERPRISE_MODE_ERROR,
     TEST_DATABASES,
     TEST_DATABASES_W_ENTERPRISE,
-    IS_KOKORO_TEST,
     FIRESTORE_ENTERPRISE_DB,
 )
 
@@ -147,10 +146,6 @@ def _verify_explain_metrics_analyze_false(explain_metrics):
 def database(request):
     from test__helpers import FIRESTORE_ENTERPRISE_DB
 
-    # enterprise mode currently does not support RunQuery calls in prod on kokoro test project
-    # TODO: remove skip when kokoro test project supports full enterprise mode
-    if request.param == FIRESTORE_ENTERPRISE_DB and IS_KOKORO_TEST:
-        pytest.skip("enterprise mode does not support RunQuery on kokoro")
     return request.param
 
 
@@ -180,11 +175,6 @@ async def verify_pipeline(query):
     modalities at the same time
     """
     from google.cloud.firestore_v1.base_aggregation import BaseAggregationQuery
-
-    # return early on kokoro. Test project doesn't currently support pipelines
-    # TODO: enable pipeline verification when kokoro test project is whitelisted
-    if IS_KOKORO_TEST:
-        pytest.skip("skipping pipeline verification on kokoro")
 
     def _clean_results(results):
         if isinstance(results, dict):
@@ -1694,7 +1684,6 @@ async def test_pipeline_explain_options_using_additional_options(
     assert "Execution:" in text_stats
 
 
-@pytest.mark.skipif(IS_KOKORO_TEST, reason="skipping pipeline verification on kokoro")
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
 async def test_pipeline_w_read_time(query_docs, cleanup, database):
     collection, stored, allowed_vals = query_docs

--- a/tests/system/test_system_async.py
+++ b/tests/system/test_system_async.py
@@ -144,8 +144,6 @@ def _verify_explain_metrics_analyze_false(explain_metrics):
 
 @pytest.fixture(scope="session")
 def database(request):
-    from test__helpers import FIRESTORE_ENTERPRISE_DB
-
     return request.param
 
 

--- a/tests/unit/v1/test_pipeline_result.py
+++ b/tests/unit/v1/test_pipeline_result.py
@@ -213,7 +213,6 @@ class TestPipelineSnapshot:
         expected_transaction = object()
         expected_read_time = 123
         expected_explain_options = object()
-        expected_index_mode = "mode"
         expected_addtl_options = {}
         source = PipelineStream(
             expected_type,
@@ -221,7 +220,6 @@ class TestPipelineSnapshot:
             expected_transaction,
             expected_read_time,
             expected_explain_options,
-            expected_index_mode,
             expected_addtl_options,
         )
         instance = self._make_one(in_arr, source)
@@ -229,7 +227,7 @@ class TestPipelineSnapshot:
         assert instance.pipeline == expected_pipeline
         assert instance._client == expected_pipeline._client
         assert instance._additonal_options == expected_addtl_options
-        assert instance._index_mode == expected_index_mode
+        assert instance._index_mode is None
         assert instance._explain_options == expected_explain_options
         assert instance._explain_stats is None
         assert instance._started is True
@@ -281,7 +279,6 @@ class SharedStreamTests:
             "transaction": None,
             "read_time": None,
             "explain_options": None,
-            "index_mode": None,
             "additional_options": {},
         }
 
@@ -312,7 +309,6 @@ class SharedStreamTests:
     @pytest.mark.parametrize(
         "init_kwargs,expected_options",
         [
-            ({"index_mode": "mode"}, {"index_mode": encode_value("mode")}),
             (
                 {"explain_options": PipelineExplainOptions()},
                 {"explain_options": encode_value({"mode": "analyze"})},
@@ -335,13 +331,6 @@ class SharedStreamTests:
                     "additional_options": {"explain_options": Constant.of("override")},
                 },
                 {"explain_options": encode_value("override")},
-            ),
-            (
-                {
-                    "index_mode": "mode",
-                    "additional_options": {"index_mode": Constant("new")},
-                },
-                {"index_mode": encode_value("new")},
             ),
         ],
     )

--- a/tests/unit/v1/test_pipeline_result.py
+++ b/tests/unit/v1/test_pipeline_result.py
@@ -227,7 +227,6 @@ class TestPipelineSnapshot:
         assert instance.pipeline == expected_pipeline
         assert instance._client == expected_pipeline._client
         assert instance._additonal_options == expected_addtl_options
-        assert instance._index_mode is None
         assert instance._explain_options == expected_explain_options
         assert instance._explain_stats is None
         assert instance._started is True


### PR DESCRIPTION
Kokoro tests for pipelines were previously disabled until the backend supports the feature. This branch will re-enable those tests, when the backend is ready

Aslo removing index_mode, since this feature was pushed back to a future release
