### PR TITLE
chore: rename Function to FunctionExpression

### DIFF
--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+.. warning::
+    **Preview API**: Firestore Pipelines is currently in preview and is 
+    subject to potential breaking changes in future releases
+"""
 
 from __future__ import annotations
 from typing import TYPE_CHECKING
@@ -50,6 +55,10 @@ class AsyncPipeline(_BasePipeline):
         ...         print(result)
 
     Use `client.pipeline()` to create instances of this class.
+
+    .. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is
+        subject to potential breaking changes in future releases
     """
 
     def __init__(self, client: AsyncClient, *stages: stages.Stage):

--- a/google/cloud/firestore_v1/async_pipeline.py
+++ b/google/cloud/firestore_v1/async_pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 .. warning::
-    **Preview API**: Firestore Pipelines is currently in preview and is 
+    **Preview API**: Firestore Pipelines is currently in preview and is
     subject to potential breaking changes in future releases
 """
 

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+.. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is 
+        subject to potential breaking changes in future releases.
+"""
 
 from __future__ import annotations
 from typing import TYPE_CHECKING
@@ -47,6 +52,10 @@ class Pipeline(_BasePipeline):
         ...         print(result)
 
     Use `client.pipeline()` to create instances of this class.
+
+    .. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is
+        subject to potential breaking changes in future releases.
     """
 
     def __init__(self, client: Client, *stages: stages.Stage):

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """
 .. warning::
-        **Preview API**: Firestore Pipelines is currently in preview and is 
-        subject to potential breaking changes in future releases.
+    **Preview API**: Firestore Pipelines is currently in preview and is 
+    subject to potential breaking changes in future releases.
 """
 
 from __future__ import annotations

--- a/google/cloud/firestore_v1/pipeline.py
+++ b/google/cloud/firestore_v1/pipeline.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 .. warning::
-    **Preview API**: Firestore Pipelines is currently in preview and is 
+    **Preview API**: Firestore Pipelines is currently in preview and is
     subject to potential breaking changes in future releases.
 """
 

--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -95,7 +95,7 @@ class Expression(ABC):
 
     - **Field references:** Access values from document fields.
     - **Literals:** Represent constant values (strings, numbers, booleans).
-    - **Function calls:** Apply functions to one or more expressions.
+    - **FunctionExpression calls:** Apply functions to one or more expressions.
     - **Aggregations:** Calculate aggregate values (e.g., sum, average) over a set of documents.
 
     The `Expression` class provides a fluent API for building expressions. You can chain
@@ -134,7 +134,7 @@ class Expression(ABC):
 
         Example:
             >>> Field.of("test").add(5)
-            >>> Function.add("test", 5)
+            >>> FunctionExpression.add("test", 5)
         """
 
         def __init__(self, instance_func):
@@ -174,7 +174,9 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the addition operation.
         """
-        return Function("add", [self, self._cast_to_expr_or_convert_to_constant(other)])
+        return FunctionExpression(
+            "add", [self, self._cast_to_expr_or_convert_to_constant(other)]
+        )
 
     @expose_as_static
     def subtract(self, other: Expression | float) -> "Expression":
@@ -192,7 +194,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the subtraction operation.
         """
-        return Function(
+        return FunctionExpression(
             "subtract", [self, self._cast_to_expr_or_convert_to_constant(other)]
         )
 
@@ -212,7 +214,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the multiplication operation.
         """
-        return Function(
+        return FunctionExpression(
             "multiply", [self, self._cast_to_expr_or_convert_to_constant(other)]
         )
 
@@ -232,7 +234,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the division operation.
         """
-        return Function(
+        return FunctionExpression(
             "divide", [self, self._cast_to_expr_or_convert_to_constant(other)]
         )
 
@@ -252,7 +254,9 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the modulo operation.
         """
-        return Function("mod", [self, self._cast_to_expr_or_convert_to_constant(other)])
+        return FunctionExpression(
+            "mod", [self, self._cast_to_expr_or_convert_to_constant(other)]
+        )
 
     @expose_as_static
     def abs(self) -> "Expression":
@@ -265,7 +269,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the absolute value.
         """
-        return Function("abs", [self])
+        return FunctionExpression("abs", [self])
 
     @expose_as_static
     def ceil(self) -> "Expression":
@@ -278,7 +282,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the ceiling value.
         """
-        return Function("ceil", [self])
+        return FunctionExpression("ceil", [self])
 
     @expose_as_static
     def exp(self) -> "Expression":
@@ -291,7 +295,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the exponential value.
         """
-        return Function("exp", [self])
+        return FunctionExpression("exp", [self])
 
     @expose_as_static
     def floor(self) -> "Expression":
@@ -304,7 +308,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the floor value.
         """
-        return Function("floor", [self])
+        return FunctionExpression("floor", [self])
 
     @expose_as_static
     def ln(self) -> "Expression":
@@ -317,7 +321,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the natural logarithm.
         """
-        return Function("ln", [self])
+        return FunctionExpression("ln", [self])
 
     @expose_as_static
     def log(self, base: Expression | float) -> "Expression":
@@ -335,7 +339,9 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the logarithm.
         """
-        return Function("log", [self, self._cast_to_expr_or_convert_to_constant(base)])
+        return FunctionExpression(
+            "log", [self, self._cast_to_expr_or_convert_to_constant(base)]
+        )
 
     @expose_as_static
     def log10(self) -> "Expression":
@@ -347,7 +353,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the logarithm.
         """
-        return Function("log10", [self])
+        return FunctionExpression("log10", [self])
 
     @expose_as_static
     def pow(self, exponent: Expression | float) -> "Expression":
@@ -365,7 +371,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the power operation.
         """
-        return Function(
+        return FunctionExpression(
             "pow", [self, self._cast_to_expr_or_convert_to_constant(exponent)]
         )
 
@@ -380,7 +386,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the rounded value.
         """
-        return Function("round", [self])
+        return FunctionExpression("round", [self])
 
     @expose_as_static
     def sqrt(self) -> "Expression":
@@ -393,7 +399,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the square root.
         """
-        return Function("sqrt", [self])
+        return FunctionExpression("sqrt", [self])
 
     @expose_as_static
     def logical_maximum(self, *others: Expression | CONSTANT_TYPE) -> "Expression":
@@ -415,7 +421,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the logical maximum operation.
         """
-        return Function(
+        return FunctionExpression(
             "maximum",
             [self] + [self._cast_to_expr_or_convert_to_constant(o) for o in others],
             infix_name_override="logical_maximum",
@@ -441,7 +447,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the logical minimum operation.
         """
-        return Function(
+        return FunctionExpression(
             "minimum",
             [self] + [self._cast_to_expr_or_convert_to_constant(o) for o in others],
             infix_name_override="logical_minimum",
@@ -630,7 +636,7 @@ class Expression(ABC):
         )
 
     @expose_as_static
-    def array_get(self, offset: Expression | int) -> "Function":
+    def array_get(self, offset: Expression | int) -> "FunctionExpression":
         """
         Creates an expression that indexes into an array from the beginning or end and returns the
         element. A negative offset starts from the end.
@@ -644,7 +650,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the `array_get` operation.
         """
-        return Function(
+        return FunctionExpression(
             "array_get", [self, self._cast_to_expr_or_convert_to_constant(offset)]
         )
 
@@ -736,7 +742,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the length of the array.
         """
-        return Function("array_length", [self])
+        return FunctionExpression("array_length", [self])
 
     @expose_as_static
     def array_reverse(self) -> "Expression":
@@ -749,7 +755,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the reversed array.
         """
-        return Function("array_reverse", [self])
+        return FunctionExpression("array_reverse", [self])
 
     @expose_as_static
     def array_concat(
@@ -767,7 +773,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the concatenated array.
         """
-        return Function(
+        return FunctionExpression(
             "array_concat",
             [self]
             + [self._cast_to_expr_or_convert_to_constant(arr) for arr in other_arrays],
@@ -783,7 +789,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the concatenated value.
         """
-        return Function(
+        return FunctionExpression(
             "concat",
             [self] + [self._cast_to_expr_or_convert_to_constant(o) for o in others],
         )
@@ -800,7 +806,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the length of the expression.
         """
-        return Function("length", [self])
+        return FunctionExpression("length", [self])
 
     @expose_as_static
     def is_absent(self) -> "BooleanExpression":
@@ -830,7 +836,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the ifAbsent operation.
         """
-        return Function(
+        return FunctionExpression(
             "if_absent",
             [self, self._cast_to_expr_or_convert_to_constant(default_value)],
         )
@@ -846,7 +852,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the isError operation.
         """
-        return Function("is_error", [self])
+        return FunctionExpression("is_error", [self])
 
     @expose_as_static
     def if_error(self, then_value: Expression | CONSTANT_TYPE) -> "Expression":
@@ -863,7 +869,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the ifError operation.
         """
-        return Function(
+        return FunctionExpression(
             "if_error", [self, self._cast_to_expr_or_convert_to_constant(then_value)]
         )
 
@@ -987,7 +993,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the length of the string.
         """
-        return Function("char_length", [self])
+        return FunctionExpression("char_length", [self])
 
     @expose_as_static
     def byte_length(self) -> "Expression":
@@ -1000,7 +1006,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the byte length of the string.
         """
-        return Function("byte_length", [self])
+        return FunctionExpression("byte_length", [self])
 
     @expose_as_static
     def like(self, pattern: Expression | str) -> "BooleanExpression":
@@ -1138,7 +1144,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the concatenated string.
         """
-        return Function(
+        return FunctionExpression(
             "string_concat",
             [self] + [self._cast_to_expr_or_convert_to_constant(el) for el in elements],
         )
@@ -1154,7 +1160,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the lowercase string.
         """
-        return Function("to_lower", [self])
+        return FunctionExpression("to_lower", [self])
 
     @expose_as_static
     def to_upper(self) -> "Expression":
@@ -1167,7 +1173,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the uppercase string.
         """
-        return Function("to_upper", [self])
+        return FunctionExpression("to_upper", [self])
 
     @expose_as_static
     def trim(self) -> "Expression":
@@ -1180,7 +1186,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the trimmed string.
         """
-        return Function("trim", [self])
+        return FunctionExpression("trim", [self])
 
     @expose_as_static
     def string_reverse(self) -> "Expression":
@@ -1193,7 +1199,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the reversed string.
         """
-        return Function("string_reverse", [self])
+        return FunctionExpression("string_reverse", [self])
 
     @expose_as_static
     def substring(
@@ -1217,7 +1223,7 @@ class Expression(ABC):
         args = [self, self._cast_to_expr_or_convert_to_constant(position)]
         if length is not None:
             args.append(self._cast_to_expr_or_convert_to_constant(length))
-        return Function("substring", args)
+        return FunctionExpression("substring", args)
 
     @expose_as_static
     def join(self, delimeter: Expression | str) -> "Expression":
@@ -1233,7 +1239,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the joined string.
         """
-        return Function(
+        return FunctionExpression(
             "join", [self, self._cast_to_expr_or_convert_to_constant(delimeter)]
         )
 
@@ -1251,7 +1257,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the value associated with the given key in the map.
         """
-        return Function(
+        return FunctionExpression(
             "map_get", [self, self._cast_to_expr_or_convert_to_constant(key)]
         )
 
@@ -1269,7 +1275,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the map_remove operation.
         """
-        return Function(
+        return FunctionExpression(
             "map_remove", [self, self._cast_to_expr_or_convert_to_constant(key)]
         )
 
@@ -1284,7 +1290,7 @@ class Expression(ABC):
 
         Example:
             >>> Map({"city": "London"}).map_merge({"country": "UK"}, {"isCapital": True})
-            >>> Field.of("settings").map_merge({"enabled":True}, Function.conditional(Field.of('isAdmin'), {"admin":True}, {}})
+            >>> Field.of("settings").map_merge({"enabled":True}, FunctionExpression.conditional(Field.of('isAdmin'), {"admin":True}, {}})
 
         Args:
             *other_maps: Sequence of maps to merge into the resulting map.
@@ -1292,7 +1298,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the value associated with the given key in the map.
         """
-        return Function(
+        return FunctionExpression(
             "map_merge",
             [self] + [self._cast_to_expr_or_convert_to_constant(m) for m in other_maps],
         )
@@ -1313,7 +1319,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the cosine distance between the two vectors.
         """
-        return Function(
+        return FunctionExpression(
             "cosine_distance",
             [
                 self,
@@ -1339,7 +1345,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the Euclidean distance between the two vectors.
         """
-        return Function(
+        return FunctionExpression(
             "euclidean_distance",
             [
                 self,
@@ -1363,7 +1369,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the dot product between the two vectors.
         """
-        return Function(
+        return FunctionExpression(
             "dot_product",
             [
                 self,
@@ -1382,7 +1388,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the length of the vector.
         """
-        return Function("vector_length", [self])
+        return FunctionExpression("vector_length", [self])
 
     @expose_as_static
     def timestamp_to_unix_micros(self) -> "Expression":
@@ -1398,7 +1404,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the number of microseconds since the epoch.
         """
-        return Function("timestamp_to_unix_micros", [self])
+        return FunctionExpression("timestamp_to_unix_micros", [self])
 
     @expose_as_static
     def unix_micros_to_timestamp(self) -> "Expression":
@@ -1412,7 +1418,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the timestamp.
         """
-        return Function("unix_micros_to_timestamp", [self])
+        return FunctionExpression("unix_micros_to_timestamp", [self])
 
     @expose_as_static
     def timestamp_to_unix_millis(self) -> "Expression":
@@ -1428,7 +1434,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the number of milliseconds since the epoch.
         """
-        return Function("timestamp_to_unix_millis", [self])
+        return FunctionExpression("timestamp_to_unix_millis", [self])
 
     @expose_as_static
     def unix_millis_to_timestamp(self) -> "Expression":
@@ -1442,7 +1448,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the timestamp.
         """
-        return Function("unix_millis_to_timestamp", [self])
+        return FunctionExpression("unix_millis_to_timestamp", [self])
 
     @expose_as_static
     def timestamp_to_unix_seconds(self) -> "Expression":
@@ -1458,7 +1464,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the number of seconds since the epoch.
         """
-        return Function("timestamp_to_unix_seconds", [self])
+        return FunctionExpression("timestamp_to_unix_seconds", [self])
 
     @expose_as_static
     def unix_seconds_to_timestamp(self) -> "Expression":
@@ -1472,7 +1478,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the timestamp.
         """
-        return Function("unix_seconds_to_timestamp", [self])
+        return FunctionExpression("unix_seconds_to_timestamp", [self])
 
     @expose_as_static
     def timestamp_add(
@@ -1494,7 +1500,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the resulting timestamp.
         """
-        return Function(
+        return FunctionExpression(
             "timestamp_add",
             [
                 self,
@@ -1523,7 +1529,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the resulting timestamp.
         """
-        return Function(
+        return FunctionExpression(
             "timestamp_subtract",
             [
                 self,
@@ -1543,7 +1549,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the collection ID.
         """
-        return Function("collection_id", [self])
+        return FunctionExpression("collection_id", [self])
 
     @expose_as_static
     def document_id(self):
@@ -1556,7 +1562,7 @@ class Expression(ABC):
         Returns:
             A new `Expression` representing the document ID.
         """
-        return Function("document_id", [self])
+        return FunctionExpression("document_id", [self])
 
     def ascending(self) -> Ordering:
         """Creates an `Ordering` that sorts documents in ascending order based on this expression.
@@ -1634,7 +1640,7 @@ class Constant(Expression, Generic[CONSTANT_TYPE]):
         return encode_value(self.value)
 
 
-class Function(Expression):
+class FunctionExpression(Expression):
     """A base class for expressions that represent function calls."""
 
     def __init__(
@@ -1652,7 +1658,7 @@ class Function(Expression):
 
     def __repr__(self):
         """
-        Most Functions can be triggered infix. Eg: Field.of('age').greater_than(18).
+        Most FunctionExpressions can be triggered infix. Eg: Field.of('age').greater_than(18).
 
         Display them this way in the repr string where possible
         """
@@ -1667,7 +1673,7 @@ class Function(Expression):
         return f"{self.__class__.__name__}({', '.join([repr(p) for p in self.params])})"
 
     def __eq__(self, other):
-        if not isinstance(other, Function):
+        if not isinstance(other, FunctionExpression):
             return False
         else:
             return other.name == self.name and other.params == self.params
@@ -1681,7 +1687,7 @@ class Function(Expression):
         )
 
 
-class AggregateFunction(Function):
+class AggregateFunction(FunctionExpression):
     """A base class for aggregation functions that operate across multiple inputs."""
 
 
@@ -1778,7 +1784,7 @@ class Field(Selectable):
         return Value(field_reference_value=self.path)
 
 
-class BooleanExpression(Function):
+class BooleanExpression(FunctionExpression):
     """Filters the given data in some way."""
 
     @staticmethod
@@ -1845,7 +1851,7 @@ class BooleanExpression(Function):
             raise TypeError(f"Unexpected filter type: {type(filter_pb)}")
 
 
-class Array(Function):
+class Array(FunctionExpression):
     """
     Creates an expression that creates a Firestore array value from an input list.
 
@@ -1868,7 +1874,7 @@ class Array(Function):
         return f"Array({self.params})"
 
 
-class Map(Function):
+class Map(FunctionExpression):
     """
     Creates an expression that creates a Firestore map value from an input dict.
 
@@ -2004,7 +2010,7 @@ class Count(AggregateFunction):
         super().__init__("count", expression_list, use_infix_repr=bool(expression_list))
 
 
-class CurrentTimestamp(Function):
+class CurrentTimestamp(FunctionExpression):
     """Creates an expression that returns the current timestamp
 
     Returns:

--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """
 .. warning::
-        **Preview API**: Firestore Pipelines is currently in preview and is 
-        subject to potential breaking changes in future releases.
+    **Preview API**: Firestore Pipelines is currently in preview and is 
+    subject to potential breaking changes in future releases.
 """
 
 from __future__ import annotations

--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 .. warning::
-    **Preview API**: Firestore Pipelines is currently in preview and is 
+    **Preview API**: Firestore Pipelines is currently in preview and is
     subject to potential breaking changes in future releases.
 """
 

--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+.. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is 
+        subject to potential breaking changes in future releases.
+"""
 
 from __future__ import annotations
 from typing import (

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+.. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is 
+        subject to potential breaking changes in future releases.
+"""
+
 
 from __future__ import annotations
 from typing import (

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 .. warning::
-    **Preview API**: Firestore Pipelines is currently in preview and is 
+    **Preview API**: Firestore Pipelines is currently in preview and is
     subject to potential breaking changes in future releases.
 """
 

--- a/google/cloud/firestore_v1/pipeline_result.py
+++ b/google/cloud/firestore_v1/pipeline_result.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 """
 .. warning::
-        **Preview API**: Firestore Pipelines is currently in preview and is 
-        subject to potential breaking changes in future releases.
+    **Preview API**: Firestore Pipelines is currently in preview and is 
+    subject to potential breaking changes in future releases.
 """
-
 
 from __future__ import annotations
 from typing import (

--- a/google/cloud/firestore_v1/pipeline_source.py
+++ b/google/cloud/firestore_v1/pipeline_source.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """
 .. warning::
-        **Preview API**: Firestore Pipelines is currently in preview and is 
-        subject to potential breaking changes in future releases.
+    **Preview API**: Firestore Pipelines is currently in preview and is 
+    subject to potential breaking changes in future releases.
 """
 
 from __future__ import annotations

--- a/google/cloud/firestore_v1/pipeline_source.py
+++ b/google/cloud/firestore_v1/pipeline_source.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 .. warning::
-    **Preview API**: Firestore Pipelines is currently in preview and is 
+    **Preview API**: Firestore Pipelines is currently in preview and is
     subject to potential breaking changes in future releases.
 """
 

--- a/google/cloud/firestore_v1/pipeline_source.py
+++ b/google/cloud/firestore_v1/pipeline_source.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+.. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is 
+        subject to potential breaking changes in future releases.
+"""
 
 from __future__ import annotations
 from typing import Generic, TypeVar, TYPE_CHECKING

--- a/google/cloud/firestore_v1/pipeline_stages.py
+++ b/google/cloud/firestore_v1/pipeline_stages.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 """
 .. warning::
-        **Preview API**: Firestore Pipelines is currently in preview and is 
-        subject to potential breaking changes in future releases.
+    **Preview API**: Firestore Pipelines is currently in preview and is 
+    subject to potential breaking changes in future releases.
 """
-
 
 from __future__ import annotations
 from typing import Optional, Sequence, TYPE_CHECKING

--- a/google/cloud/firestore_v1/pipeline_stages.py
+++ b/google/cloud/firestore_v1/pipeline_stages.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+.. warning::
+        **Preview API**: Firestore Pipelines is currently in preview and is 
+        subject to potential breaking changes in future releases.
+"""
+
 
 from __future__ import annotations
 from typing import Optional, Sequence, TYPE_CHECKING

--- a/google/cloud/firestore_v1/pipeline_stages.py
+++ b/google/cloud/firestore_v1/pipeline_stages.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 .. warning::
-    **Preview API**: Firestore Pipelines is currently in preview and is 
+    **Preview API**: Firestore Pipelines is currently in preview and is
     subject to potential breaking changes in future releases.
 """
 

--- a/tests/system/pipeline_e2e/aggregates.yaml
+++ b/tests/system/pipeline_e2e/aggregates.yaml
@@ -4,7 +4,7 @@ tests:
       - Collection: books
       - Aggregate:
         - AliasedExpression:
-            - Function.count:
+            - FunctionExpression.count:
               - Field: rating
             - "count"
     assert_results:
@@ -30,8 +30,8 @@ tests:
       - Collection: books
       - Aggregate:
         - AliasedExpression:
-            - Function.count_if:
-              - Function.greater_than:
+            - FunctionExpression.count_if:
+              - FunctionExpression.greater_than:
                 - Field: rating
                 - Constant: 4.2
             - "count_if_rating_gt_4_2"
@@ -62,7 +62,7 @@ tests:
       - Collection: books
       - Aggregate:
         - AliasedExpression:
-            - Function.count_distinct:
+            - FunctionExpression.count_distinct:
               - Field: genre
             - "distinct_genres"
     assert_results:
@@ -87,20 +87,20 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: genre
               - Constant: Science Fiction
       - Aggregate:
         - AliasedExpression:
-            - Function.count:
+            - FunctionExpression.count:
               - Field: rating
             - "count"
         - AliasedExpression:
-            - Function.average:
+            - FunctionExpression.average:
               - Field: rating
             - "avg_rating"
         - AliasedExpression:
-            - Function.maximum:
+            - FunctionExpression.maximum:
               - Field: rating
             - "max_rating"
     assert_results:
@@ -144,7 +144,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-        - Function.less_than:
+        - FunctionExpression.less_than:
           - Field: published
           - Constant: 1900
       - Aggregate:
@@ -155,18 +155,18 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.less_than:
+          - FunctionExpression.less_than:
               - Field: published
               - Constant: 1984
       - Aggregate:
           accumulators:
             - AliasedExpression:
-              - Function.average:
+              - FunctionExpression.average:
                 - Field: rating
               - "avg_rating"
           groups: [genre]
       - Where:
-          - Function.greater_than:
+          - FunctionExpression.greater_than:
               - Field: avg_rating
               - Constant: 4.3
       - Sort:
@@ -226,15 +226,15 @@ tests:
       - Collection: books
       - Aggregate:
           - AliasedExpression:
-              - Function.count:
+              - FunctionExpression.count:
                 - Field: rating
               - "count"
           - AliasedExpression:
-              - Function.maximum:
+              - FunctionExpression.maximum:
                 - Field: rating
               - "max_rating"
           - AliasedExpression:
-              - Function.minimum:
+              - FunctionExpression.minimum:
                 - Field: published
               - "min_published"
     assert_results:
@@ -271,12 +271,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: genre
               - Constant: Science Fiction
       - Aggregate:
         - AliasedExpression:
-            - Function.sum:
+            - FunctionExpression.sum:
               - Field: rating
             - "total_rating"
     assert_results:

--- a/tests/system/pipeline_e2e/array.yaml
+++ b/tests/system/pipeline_e2e/array.yaml
@@ -3,7 +3,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.array_contains:
+          - FunctionExpression.array_contains:
               - Field: tags
               - Constant: comedy
     assert_results:
@@ -33,7 +33,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.array_contains_any:
+          - FunctionExpression.array_contains_any:
             - Field: tags
             - - Constant: comedy
               - Constant: classic
@@ -81,7 +81,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.array_contains_all:
+          - FunctionExpression.array_contains_all:
               - Field: tags
               - - Constant: adventure
                 - Constant: magic
@@ -117,11 +117,11 @@ tests:
       - Collection: books
       - Select:
         - AliasedExpression:
-            - Function.array_length:
+            - FunctionExpression.array_length:
                 - Field: tags
             - "tagsCount"
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: tagsCount
               - Constant: 3
     assert_results: # All documents have 3 tags
@@ -161,12 +161,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.array_reverse:
+            - FunctionExpression.array_reverse:
                 - Field: tags
             - "reversedTags"
     assert_results:
@@ -178,12 +178,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.array_concat:
+            - FunctionExpression.array_concat:
                 - Field: tags
                 - ["new_tag", "another_tag"]
             - "concatenatedTags"
@@ -225,12 +225,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "Dune"
       - Select:
         - AliasedExpression:
-            - Function.array_concat:
+            - FunctionExpression.array_concat:
                 - Field: tags
                 - ["sci-fi"]
                 - ["classic", "epic"]
@@ -279,12 +279,12 @@ tests:
       - Collection: books
       - AddFields:
         - AliasedExpression:
-            - Function.array_concat:
+            - FunctionExpression.array_concat:
                 - Field: tags
                 - Array: ["Dystopian"]
             - "new_tags"
       - Where:
-          - Function.array_contains_any:
+          - FunctionExpression.array_contains_any:
             - Field: new_tags
             - - Constant: non_existent_tag
               - Field: genre
@@ -352,7 +352,7 @@ tests:
       - Limit: 1
       - Select:
         - AliasedExpression:
-            - Function.array_concat:
+            - FunctionExpression.array_concat:
                 - Array: [1, 2, 3]
                 - Array: [4, 5]
             - "concatenated"
@@ -390,12 +390,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.array_get:
+            - FunctionExpression.array_get:
                 - Field: tags
                 - Constant: 0
             - "firstTag"
@@ -428,12 +428,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.array_get:
+            - FunctionExpression.array_get:
                 - Field: tags
                 - Constant: -1
             - "lastTag"

--- a/tests/system/pipeline_e2e/date_and_time.yaml
+++ b/tests/system/pipeline_e2e/date_and_time.yaml
@@ -6,13 +6,13 @@ tests:
       - Select:
         - AliasedExpression:
             - And:
-              - Function.greater_than_or_equal:
+              - FunctionExpression.greater_than_or_equal:
                   - CurrentTimestamp: []
-                  - Function.unix_seconds_to_timestamp:
+                  - FunctionExpression.unix_seconds_to_timestamp:
                     - Constant: 1735689600 # 2025-01-01
-              - Function.less_than:
+              - FunctionExpression.less_than:
                   - CurrentTimestamp: []
-                  - Function.unix_seconds_to_timestamp:
+                  - FunctionExpression.unix_seconds_to_timestamp:
                     - Constant: 4892438400 # 2125-01-01
             - "is_between_2025_and_2125"
     assert_results:
@@ -52,42 +52,42 @@ tests:
                             args:
                             - integerValue: '4892438400'
           name: select
-  - description: testTimestampFunctions
+  - description: testTimestampFunctionExpressions
     pipeline:
       - Collection: timestamps
       - Select:
         - AliasedExpression:
-            - Function.timestamp_to_unix_micros:
+            - FunctionExpression.timestamp_to_unix_micros:
                 - Field: time
             - "micros"
         - AliasedExpression:
-            - Function.timestamp_to_unix_millis:
+            - FunctionExpression.timestamp_to_unix_millis:
                 - Field: time
             - "millis"
         - AliasedExpression:
-            - Function.timestamp_to_unix_seconds:
+            - FunctionExpression.timestamp_to_unix_seconds:
                 - Field: time
             - "seconds"
         - AliasedExpression:
-            - Function.unix_micros_to_timestamp:
+            - FunctionExpression.unix_micros_to_timestamp:
                 - Field: micros
             - "from_micros"
         - AliasedExpression:
-            - Function.unix_millis_to_timestamp:
+            - FunctionExpression.unix_millis_to_timestamp:
                 - Field: millis
             - "from_millis"
         - AliasedExpression:
-            - Function.unix_seconds_to_timestamp:
+            - FunctionExpression.unix_seconds_to_timestamp:
                 - Field: seconds
             - "from_seconds"
         - AliasedExpression:
-            - Function.timestamp_add:
+            - FunctionExpression.timestamp_add:
                 - Field: time
                 - Constant: "day"
                 - Constant: 1
             - "plus_day"
         - AliasedExpression:
-            - Function.timestamp_subtract:
+            - FunctionExpression.timestamp_subtract:
                 - Field: time
                 - Constant: "hour"
                 - Constant: 1

--- a/tests/system/pipeline_e2e/general.yaml
+++ b/tests/system/pipeline_e2e/general.yaml
@@ -57,13 +57,13 @@ tests:
       - Collection: books
       - AddFields:
         - AliasedExpression:
-            - Function.string_concat:
+            - FunctionExpression.string_concat:
                 - Field: author
                 - Constant: _
                 - Field: title
             - "author_title"
         - AliasedExpression:
-            - Function.string_concat:
+            - FunctionExpression.string_concat:
                 - Field: title
                 - Constant: _
                 - Field: author
@@ -227,14 +227,14 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: genre
               - Constant: Romance
       - Union:
         - Pipeline:
             - Collection: books
             - Where:
-                - Function.equal:
+                - FunctionExpression.equal:
                     - Field: genre
                     - Constant: Dystopian
       - Select:
@@ -299,12 +299,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.document_id:
+            - FunctionExpression.document_id:
                 - Field: __name__
             - "doc_id"
     assert_results:
@@ -337,7 +337,7 @@ tests:
       - Limit: 1
       - Select:
         - AliasedExpression:
-            - Function.collection_id:
+            - FunctionExpression.collection_id:
                 - Field: __name__
             - "collectionName"
     assert_results:
@@ -481,7 +481,7 @@ tests:
       - Select:
         - AliasedExpression:
           - Conditional:
-            - Function.greater_than_or_equal:
+            - FunctionExpression.greater_than_or_equal:
               - Field: count
               - Constant: 10
             - Constant: True
@@ -536,7 +536,7 @@ tests:
               reference_value: "/books"
       - RawStage:
         - "where"
-        - Function.equal:
+        - FunctionExpression.equal:
           - Field: title
           - Constant: The Hitchhiker's Guide to the Galaxy
       - RawStage:
@@ -571,7 +571,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
           - Field: title
           - Constant: The Hitchhiker's Guide to the Galaxy
       - Unnest:
@@ -609,7 +609,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
           - Field: title
           - Constant: The Hitchhiker's Guide to the Galaxy
       - Unnest:
@@ -660,7 +660,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
           - Field: title
           - Constant: "The Hitchhiker's Guide to the Galaxy"
       - ReplaceWith:

--- a/tests/system/pipeline_e2e/logical.yaml
+++ b/tests/system/pipeline_e2e/logical.yaml
@@ -4,10 +4,10 @@ tests:
       - Collection: books
       - Where:
           - And:
-              - Function.greater_than:
+              - FunctionExpression.greater_than:
                   - Field: rating
                   - Constant: 4.5
-              - Function.equal:
+              - FunctionExpression.equal:
                   - Field: genre
                   - Constant: Science Fiction
     assert_results:
@@ -49,10 +49,10 @@ tests:
       - Collection: books
       - Where:
           - Or:
-              - Function.equal:
+              - FunctionExpression.equal:
                   - Field: genre
                   - Constant: Romance
-              - Function.equal:
+              - FunctionExpression.equal:
                   - Field: genre
                   - Constant: Dystopian
       - Select:
@@ -105,13 +105,13 @@ tests:
       - Collection: books
       - Where:
           - And:
-              - Function.greater_than:
+              - FunctionExpression.greater_than:
                   - Field: rating
                   - Constant: 4.2
-              - Function.less_than_or_equal:
+              - FunctionExpression.less_than_or_equal:
                   - Field: rating
                   - Constant: 4.5
-              - Function.not_equal:
+              - FunctionExpression.not_equal:
                   - Field: genre
                   - Constant: Science Fiction
       - Select:
@@ -176,13 +176,13 @@ tests:
       - Where:
           - Or:
               - And:
-                  - Function.greater_than:
+                  - FunctionExpression.greater_than:
                       - Field: rating
                       - Constant: 4.5
-                  - Function.equal:
+                  - FunctionExpression.equal:
                       - Field: genre
                       - Constant: Science Fiction
-              - Function.less_than:
+              - FunctionExpression.less_than:
                   - Field: published
                   - Constant: 1900
       - Select:
@@ -242,7 +242,7 @@ tests:
     pipeline:
       - Collection: errors
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
             - Field: value
             - null
     assert_results:
@@ -264,7 +264,7 @@ tests:
     pipeline:
       - Collection: errors
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
             - Field: value
             - NaN
     assert_count: 1
@@ -285,7 +285,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.is_absent:
+          - FunctionExpression.is_absent:
               - Field: awards.pulitzer
     assert_count: 9
     assert_proto:
@@ -305,13 +305,13 @@ tests:
       - Collection: books
       - Select:
         - AliasedExpression:
-            - Function.if_absent:
+            - FunctionExpression.if_absent:
                 - Field: awards.pulitzer
                 - Constant: false
             - "pulitzer_award"
         - title
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: pulitzer_award
               - Constant: true
     assert_results:
@@ -347,8 +347,8 @@ tests:
       - Collection: books
       - Select:
         - AliasedExpression:
-            - Function.is_error:
-                - Function.divide:
+            - FunctionExpression.is_error:
+                - FunctionExpression.divide:
                     - Field: rating
                     - Constant: "string"
             - "is_error_result"
@@ -382,8 +382,8 @@ tests:
       - Collection: books
       - Select:
         - AliasedExpression:
-            - Function.if_error:
-                - Function.divide:
+            - FunctionExpression.if_error:
+                - FunctionExpression.divide:
                     - Field: rating
                     - Field: genre
                 - Constant: "An error occurred"
@@ -418,17 +418,17 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: Douglas Adams
       - Select:
           - AliasedExpression:
-              - Function.logical_maximum:
+              - FunctionExpression.logical_maximum:
                   - Field: rating
                   - Constant: 4.5
               - "max_rating"
           - AliasedExpression:
-              - Function.logical_minimum:
+              - FunctionExpression.logical_minimum:
                   - Field: published
                   - Constant: 1900
               - "min_published"
@@ -468,19 +468,19 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: Douglas Adams
       - Select:
           - AliasedExpression:
-              - Function.logical_maximum:
+              - FunctionExpression.logical_maximum:
                   - Field: rating
                   - Constant: 4.5
                   - Constant: 3.0
                   - Constant: 5.0
               - "max_rating"
           - AliasedExpression:
-              - Function.logical_minimum:
+              - FunctionExpression.logical_minimum:
                   - Field: published
                   - Constant: 1900
                   - Constant: 2000
@@ -526,7 +526,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.greater_than_or_equal:
+          - FunctionExpression.greater_than_or_equal:
               - Field: rating
               - Constant: 4.6
       - Select:
@@ -546,11 +546,11 @@ tests:
       - Collection: books
       - Where:
           - And:
-            - Function.equal_any:
+            - FunctionExpression.equal_any:
                 - Field: genre
                 - - Constant: Romance
                   - Constant: Dystopian
-            - Function.not_equal_any:
+            - FunctionExpression.not_equal_any:
                 - Field: author
                 - - Constant: "George Orwell"
     assert_results:
@@ -582,9 +582,9 @@ tests:
       - Collection: books
       - Where:
           - And:
-            - Function.exists:
+            - FunctionExpression.exists:
               - Field: awards.pulitzer
-            - Function.equal:
+            - FunctionExpression.equal:
               - Field: awards.pulitzer
               - Constant: true
       - Select:
@@ -596,10 +596,10 @@ tests:
       - Collection: books
       - Where:
           - Xor:
-            - - Function.equal:
+            - - FunctionExpression.equal:
                   - Field: genre
                   - Constant: Romance
-              - Function.greater_than:
+              - FunctionExpression.greater_than:
                   - Field: published
                   - Constant: 1980
       - Select:
@@ -624,7 +624,7 @@ tests:
         - title
         - AliasedExpression:
             - Conditional:
-                - Function.greater_than:
+                - FunctionExpression.greater_than:
                     - Field: published
                     - Constant: 1950
                 - Constant: "Modern"
@@ -648,7 +648,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.greater_than:
+          - FunctionExpression.greater_than:
               - Field: published
               - Field: rating
       - Select:
@@ -658,14 +658,14 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.exists:
+          - FunctionExpression.exists:
               - Field: non_existent_field
     assert_count: 0
   - description: testConditionalWithFields
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal_any:
+          - FunctionExpression.equal_any:
               - Field: title
               - - Constant: "Dune"
                 - Constant: "1984"
@@ -673,7 +673,7 @@ tests:
         - title
         - AliasedExpression:
             - Conditional:
-                - Function.greater_than:
+                - FunctionExpression.greater_than:
                     - Field: published
                     - Constant: 1950
                 - Field: author

--- a/tests/system/pipeline_e2e/map.yaml
+++ b/tests/system/pipeline_e2e/map.yaml
@@ -8,13 +8,13 @@ tests:
           - DESCENDING
       - Select:
           - AliasedExpression:
-              - Function.map_get:
+              - FunctionExpression.map_get:
                   - Field: awards
                   - hugo
               - "hugoAward"
           - Field: title
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: hugoAward
               - Constant: true
     assert_results:
@@ -59,7 +59,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "Dune"
       - AddFields:
@@ -68,7 +68,7 @@ tests:
             - "award_name"
       - Select:
           - AliasedExpression:
-              - Function.map_get:
+              - FunctionExpression.map_get:
                   - Field: awards
                   - Field: award_name
               - "hugoAward"
@@ -111,12 +111,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "Dune"
       - Select:
         - AliasedExpression:
-            - Function.map_remove:
+            - FunctionExpression.map_remove:
                 - Field: awards
                 - "nebula"
             - "awards_removed"
@@ -150,12 +150,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "Dune"
       - Select:
         - AliasedExpression:
-            - Function.map_merge:
+            - FunctionExpression.map_merge:
                 - Field: awards
                 - Map:
                    elements: {"new_award": true, "hugo": false}
@@ -206,7 +206,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: awards.hugo
               - Constant: true
       - Sort:
@@ -256,7 +256,7 @@ tests:
       - Limit: 1
       - Select:
         - AliasedExpression:
-            - Function.map_merge:
+            - FunctionExpression.map_merge:
                 - Map:
                     elements: {"a": "orig", "b": "orig"}
                 - Map:

--- a/tests/system/pipeline_e2e/math.yaml
+++ b/tests/system/pipeline_e2e/math.yaml
@@ -3,61 +3,61 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "Dune"
       - Select:
         - AliasedExpression:
-            - Function.add:
+            - FunctionExpression.add:
                 - Field: published
                 - Field: rating
             - "pub_plus_rating"
     assert_results:
       - pub_plus_rating: 1969.6
-  - description: testMathFunctionessions
+  - description: testMathFunctionExpressionessions
     pipeline:
       - Collection: books
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
           - Field: title
           - Constant: To Kill a Mockingbird
       - Select:
         - AliasedExpression:
-            - Function.abs:
+            - FunctionExpression.abs:
                 - Field: rating
             - "abs_rating"
         - AliasedExpression:
-            - Function.ceil:
+            - FunctionExpression.ceil:
                 - Field: rating
             - "ceil_rating"
         - AliasedExpression:
-            - Function.exp:
+            - FunctionExpression.exp:
                 - Field: rating
             - "exp_rating"
         - AliasedExpression:
-            - Function.floor:
+            - FunctionExpression.floor:
                 - Field: rating
             - "floor_rating"
         - AliasedExpression:
-            - Function.ln:
+            - FunctionExpression.ln:
                 - Field: rating
             - "ln_rating"
         - AliasedExpression:
-            - Function.log10:
+            - FunctionExpression.log10:
                 - Field: rating
             - "log_rating_base10"
         - AliasedExpression:
-            - Function.log:
+            - FunctionExpression.log:
                 - Field: rating
                 - Constant: 2
             - "log_rating_base2"
         - AliasedExpression:
-            - Function.pow:
+            - FunctionExpression.pow:
                 - Field: rating
                 - Constant: 2
             - "pow_rating"
         - AliasedExpression:
-            - Function.sqrt:
+            - FunctionExpression.sqrt:
                 - Field: rating
             - "sqrt_rating"
     assert_results_approximate:
@@ -134,11 +134,11 @@ tests:
                     - fieldReferenceValue: rating
                     name: sqrt
           name: select
-  - description: testRoundFunctionessions
+  - description: testRoundFunctionExpressionessions
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal_any:
+          - FunctionExpression.equal_any:
               - Field: title
               - - Constant: "To Kill a Mockingbird" # rating 4.2
                 - Constant: "Pride and Prejudice" # rating 4.5
@@ -146,7 +146,7 @@ tests:
       - Select:
         - title
         - AliasedExpression:
-            - Function.round:
+            - FunctionExpression.round:
                 - Field: rating
             - "round_rating"
       - Sort:
@@ -201,42 +201,42 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-        - Function.equal:
+        - FunctionExpression.equal:
           - Field: title
           - Constant: To Kill a Mockingbird
       - Select:
         - AliasedExpression:
-            - Function.add:
+            - FunctionExpression.add:
                 - Field: rating
                 - Constant: 1
             - "ratingPlusOne"
         - AliasedExpression:
-            - Function.subtract:
+            - FunctionExpression.subtract:
                 - Field: published
                 - Constant: 1900
             - "yearsSince1900"
         - AliasedExpression:
-            - Function.multiply:
+            - FunctionExpression.multiply:
                 - Field: rating
                 - Constant: 10
             - "ratingTimesTen"
         - AliasedExpression:
-            - Function.divide:
+            - FunctionExpression.divide:
                 - Field: rating
                 - Constant: 2
             - "ratingDividedByTwo"
         - AliasedExpression:
-            - Function.multiply:
+            - FunctionExpression.multiply:
                 - Field: rating
                 - Constant: 20
             - "ratingTimes20"
         - AliasedExpression:
-            - Function.add:
+            - FunctionExpression.add:
                 - Field: rating
                 - Constant: 3
             - "ratingPlus3"
         - AliasedExpression:
-            - Function.mod:
+            - FunctionExpression.mod:
                 - Field: rating
                 - Constant: 2
             - "ratingMod2"

--- a/tests/system/pipeline_e2e/string.yaml
+++ b/tests/system/pipeline_e2e/string.yaml
@@ -8,7 +8,7 @@ tests:
             - ASCENDING
       - Select:
           - AliasedExpression:
-              - Function.string_concat:
+              - FunctionExpression.string_concat:
                   - Field: author
                   - Constant: " - "
                   - Field: title
@@ -48,7 +48,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.starts_with:
+          - FunctionExpression.starts_with:
               - Field: title
               - Constant: The
       - Select:
@@ -93,7 +93,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.ends_with:
+          - FunctionExpression.ends_with:
               - Field: title
               - Constant: y
       - Select:
@@ -136,18 +136,18 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.concat:
+            - FunctionExpression.concat:
                 - Field: author
                 - Constant: ": "
                 - Field: title
             - "author_title"
         - AliasedExpression:
-            - Function.concat:
+            - FunctionExpression.concat:
                 - Field: tags
                 - - Constant: "new_tag"
             - "concatenatedTags"
@@ -162,20 +162,20 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: title
               - Constant: "The Hitchhiker's Guide to the Galaxy"
       - Select:
         - AliasedExpression:
-            - Function.length:
+            - FunctionExpression.length:
                 - Field: title
             - "titleLength"
         - AliasedExpression:
-            - Function.length:
+            - FunctionExpression.length:
                 - Field: tags
             - "tagsLength"
         - AliasedExpression:
-            - Function.length:
+            - FunctionExpression.length:
                 - Field: awards
             - "awardsLength"
     assert_results:
@@ -187,12 +187,12 @@ tests:
       - Collection: books
       - Select:
         - AliasedExpression:
-            - Function.char_length:
+            - FunctionExpression.char_length:
                 - Field: title
             - "titleLength"
         - title
       - Where:
-          - Function.greater_than:
+          - FunctionExpression.greater_than:
               - Field: titleLength
               - Constant: 20
       - Sort:
@@ -244,12 +244,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Douglas Adams"
       - Select:
         - AliasedExpression:
-            - Function.char_length:
+            - FunctionExpression.char_length:
                 - Field: title
             - "title_length"
     assert_results:
@@ -280,13 +280,13 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: Douglas Adams
       - Select:
         - AliasedExpression:
-            - Function.byte_length:
-                - Function.string_concat:
+            - FunctionExpression.byte_length:
+                - FunctionExpression.string_concat:
                   - Field: title
                   - Constant: _银河系漫游指南
             - "title_byte_length"
@@ -322,7 +322,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.like:
+          - FunctionExpression.like:
               - Field: title
               - Constant: "%Guide%"
       - Select:
@@ -334,7 +334,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.regex_contains:
+          - FunctionExpression.regex_contains:
               - Field: title
               - Constant: "(?i)(the|of)"
     assert_count: 5
@@ -356,7 +356,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.regex_match:
+          - FunctionExpression.regex_match:
               - Field: title
               - Constant: ".*(?i)(the|of).*"
     assert_count: 5
@@ -377,7 +377,7 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.string_contains:
+          - FunctionExpression.string_contains:
               - Field: title
               - Constant: "Hitchhiker's"
       - Select:
@@ -388,12 +388,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Douglas Adams"
       - Select:
         - AliasedExpression:
-            - Function.to_lower:
+            - FunctionExpression.to_lower:
                 - Field: title
             - "lower_title"
     assert_results:
@@ -424,12 +424,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Douglas Adams"
       - Select:
         - AliasedExpression:
-            - Function.to_upper:
+            - FunctionExpression.to_upper:
                 - Field: title
             - "upper_title"
     assert_results:
@@ -460,13 +460,13 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Douglas Adams"
       - Select:
         - AliasedExpression:
-            - Function.trim:
-                - Function.string_concat:
+            - FunctionExpression.trim:
+                - FunctionExpression.string_concat:
                   - Constant: "  "
                   - Field: title
                   - Constant: "  "
@@ -504,12 +504,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Jane Austen"
       - Select:
         - AliasedExpression:
-            - Function.string_reverse:
+            - FunctionExpression.string_reverse:
                 - Field: title
             - "reversed_title"
     assert_results:
@@ -540,12 +540,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Douglas Adams"
       - Select:
         - AliasedExpression:
-            - Function.substring:
+            - FunctionExpression.substring:
                 - Field: title
                 - Constant: 4
                 - Constant: 11
@@ -580,12 +580,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Fyodor Dostoevsky"
       - Select:
         - AliasedExpression:
-            - Function.substring:
+            - FunctionExpression.substring:
                 - Field: title
                 - Constant: 10
             - "substring_title"
@@ -618,12 +618,12 @@ tests:
     pipeline:
       - Collection: books
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: author
               - Constant: "Douglas Adams"
       - Select:
         - AliasedExpression:
-            - Function.join:
+            - FunctionExpression.join:
                 - Field: tags
                 - Constant: ", "
             - "joined_tags"

--- a/tests/system/pipeline_e2e/vector.yaml
+++ b/tests/system/pipeline_e2e/vector.yaml
@@ -4,7 +4,7 @@ tests:
       - Collection: vectors
       - Select:
         - AliasedExpression:
-            - Function.vector_length:
+            - FunctionExpression.vector_length:
                 - Field: embedding
             - "embedding_length"
       - Sort:
@@ -117,12 +117,12 @@ tests:
     pipeline:
       - Collection: vectors
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: embedding
               - Vector: [1.0, 2.0, 3.0]
       - Select:
         - AliasedExpression:
-            - Function.dot_product:
+            - FunctionExpression.dot_product:
                 - Field: embedding
                 - Vector: [1.0, 1.0, 1.0]
             - "dot_product_result"
@@ -132,12 +132,12 @@ tests:
     pipeline:
       - Collection: vectors
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: embedding
               - Vector: [1.0, 2.0, 3.0]
       - Select:
         - AliasedExpression:
-            - Function.euclidean_distance:
+            - FunctionExpression.euclidean_distance:
                 - Field: embedding
                 - Vector: [1.0, 2.0, 3.0]
             - "euclidean_distance_result"
@@ -147,12 +147,12 @@ tests:
     pipeline:
       - Collection: vectors
       - Where:
-          - Function.equal:
+          - FunctionExpression.equal:
               - Field: embedding
               - Vector: [1.0, 2.0, 3.0]
       - Select:
         - AliasedExpression:
-            - Function.cosine_distance:
+            - FunctionExpression.cosine_distance:
                 - Field: embedding
                 - Vector: [1.0, 2.0, 3.0]
             - "cosine_distance_result"

--- a/tests/unit/v1/test_pipeline_expressions.py
+++ b/tests/unit/v1/test_pipeline_expressions.py
@@ -566,12 +566,12 @@ class TestBooleanExpression:
             BooleanExpression._from_query_filter_pb(document_pb.Value(), mock_client)
 
 
-class TestFunction:
+class TestFunctionExpression:
     def test_equals(self):
-        assert expr.Function.sqrt("1") == expr.Function.sqrt("1")
-        assert expr.Function.sqrt("1") != expr.Function.sqrt("2")
-        assert expr.Function.sqrt("1") != expr.Function.sum("1")
-        assert expr.Function.sqrt("1") != object()
+        assert expr.FunctionExpression.sqrt("1") == expr.FunctionExpression.sqrt("1")
+        assert expr.FunctionExpression.sqrt("1") != expr.FunctionExpression.sqrt("2")
+        assert expr.FunctionExpression.sqrt("1") != expr.FunctionExpression.sum("1")
+        assert expr.FunctionExpression.sqrt("1") != object()
 
 
 class TestArray:


### PR DESCRIPTION
Rename Function to FunctionExpression, and add a warning that other changes in the API surface may come before GA