### PR TITLE
fix: improve pipeline create_from

### DIFF
--- a/google/cloud/firestore_v1/base_aggregation.py
+++ b/google/cloud/firestore_v1/base_aggregation.py
@@ -361,12 +361,8 @@ class BaseAggregationQuery(ABC):
         """
         Convert this query into a Pipeline
 
-        Queries containing a `cursor` or `limit_to_last` are not currently supported
-
         Args:
             source: the PipelineSource to build the pipeline off of
-        Raises:
-            - NotImplementedError: raised if the query contains a `cursor` or `limit_to_last`
         Returns:
             a Pipeline representing the query
         """

--- a/google/cloud/firestore_v1/base_collection.py
+++ b/google/cloud/firestore_v1/base_collection.py
@@ -608,12 +608,8 @@ class BaseCollectionReference(Generic[QueryType]):
         """
         Convert this query into a Pipeline
 
-        Queries containing a `cursor` or `limit_to_last` are not currently supported
-
         Args:
             source: the PipelineSource to build the pipeline off o
-        Raises:
-            - NotImplementedError: raised if the query contains a `cursor` or `limit_to_last`
         Returns:
             a Pipeline representing the query
         """

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -1187,15 +1187,6 @@ class BaseQuery(object):
                 orderings.append(pipeline_expressions.Ordering(field, direction))
 
         if orderings:
-            # Normalize cursors to get the raw values corresponding to the orders
-            start_at_val = None
-            if self._start_at:
-                start_at_val = self._normalize_cursor(self._start_at, normalized_orders)
-
-            end_at_val = None
-            if self._end_at:
-                end_at_val = self._normalize_cursor(self._end_at, normalized_orders)
-
             # If limit_to_last is set, we need to reverse the orderings to find the
             # "last" N documents (which effectively become the "first" N in reverse order).
             if self._limit_to_last:
@@ -1205,14 +1196,17 @@ class BaseQuery(object):
             # Apply cursor conditions.
             # Cursors are translated into filter conditions (e.g., field > value)
             # based on the orderings.
-            if start_at_val:
+            if self._start_at:
+                # Normalize cursors to get the raw values corresponding to the orders
+                start_at_val = self._normalize_cursor(self._start_at, normalized_orders)
                 ppl = ppl.where(
                     _where_conditions_from_cursor(
                         start_at_val, orderings, is_start_cursor=True
                     )
                 )
 
-            if end_at_val:
+            if self._end_at:
+                end_at_val = self._normalize_cursor(self._end_at, normalized_orders)
                 ppl = ppl.where(
                     _where_conditions_from_cursor(
                         end_at_val, orderings, is_start_cursor=False

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -1184,9 +1184,9 @@ class BaseQuery(object):
 
         # Apply cursors as filters.
         if orderings:
-            for cursor_data, is_start in [(self._start_at, True), (self._end_at, False)]:
-                if cursor_data:
-                    val = self._normalize_cursor(cursor_data, normalized_orders)
+            for cursor, is_start in [(self._start_at, True), (self._end_at, False)]:
+                if cursor:
+                    val = self._normalize_cursor(cursor, normalized_orders)
                     ppl = ppl.where(
                         _where_conditions_from_cursor(val, orderings, is_start)
                     )

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -1134,12 +1134,8 @@ class BaseQuery(object):
         """
         Convert this query into a Pipeline
 
-        Queries containing a `cursor` or `limit_to_last` are not currently supported
-
         Args:
             source: the PipelineSource to build the pipeline off of
-        Raises:
-            - NotImplementedError: raised if the query contains a `cursor` or `limit_to_last`
         Returns:
             a Pipeline representing the query
         """
@@ -1162,9 +1158,10 @@ class BaseQuery(object):
 
         # Orders
         orders = self._normalize_orders()
+
+        exists = []
+        orderings = []
         if orders:
-            exists = []
-            orderings = []
             for order in orders:
                 field = pipeline_expressions.Field.of(order.field.field_path)
                 exists.append(field.exists())
@@ -1178,22 +1175,58 @@ class BaseQuery(object):
             # Add exists filters to match Query's implicit orderby semantics.
             if len(exists) == 1:
                 ppl = ppl.where(exists[0])
-            else:
+            elif len(exists) > 1:
                 ppl = ppl.where(pipeline_expressions.And(*exists))
 
-            # Add sort orderings
-            ppl = ppl.sort(*orderings)
+        if orderings:
+            # Normalize cursors to get the raw values corresponding to the orders
+            start_at_val = None
+            if self._start_at:
+                start_at_val = self._normalize_cursor(self._start_at, orders)
 
-        # Cursors, Limit and Offset
-        if self._start_at or self._end_at or self._limit_to_last:
-            raise NotImplementedError(
-                "Query to Pipeline conversion: cursors and limit_to_last is not supported yet."
-            )
-        else:  # Limit & Offset without cursors
-            if self._offset:
-                ppl = ppl.offset(self._offset)
-            if self._limit:
+            end_at_val = None
+            if self._end_at:
+                end_at_val = self._normalize_cursor(self._end_at, orders)
+
+            # If limit_to_last is set, we need to reverse the orderings to find the
+            # "last" N documents (which effectively become the "first" N in reverse order).
+            if self._limit_to_last:
+                actual_orderings = _reverse_orderings(orderings)
+                ppl = ppl.sort(*actual_orderings)
+
+            # Apply cursor conditions.
+            # Cursors are translated into filter conditions (e.g., field > value)
+            # based on the orderings.
+            if start_at_val:
+                ppl = ppl.where(
+                    _where_conditions_from_cursor(
+                        start_at_val, orderings, is_start_cursor=True
+                    )
+                )
+
+            if end_at_val:
+                ppl = ppl.where(
+                    _where_conditions_from_cursor(
+                        end_at_val, orderings, is_start_cursor=False
+                    )
+                )
+
+            if not self._limit_to_last:
+                ppl = ppl.sort(*orderings)
+
+            if self._limit is not None:
                 ppl = ppl.limit(self._limit)
+
+            # If we reversed the orderings for limit_to_last, we must now re-sort
+            # using the original orderings to return the results in the user-requested order.
+            if self._limit_to_last:
+                ppl = ppl.sort(*orderings)
+        elif self._limit is not None and not self._limit_to_last:
+            ppl = ppl.limit(self._limit)
+
+        # Offset
+        if self._offset:
+            ppl = ppl.offset(self._offset)
 
         return ppl
 
@@ -1364,6 +1397,69 @@ def _cursor_pb(cursor_pair: Optional[Tuple[list, bool]]) -> Optional[Cursor]:
         return query.Cursor(values=value_pbs, before=before)
     else:
         return None
+
+
+def _where_conditions_from_cursor(
+    cursor: Tuple[List, bool],
+    orderings: List[pipeline_expressions.Ordering],
+    is_start_cursor: bool,
+) -> pipeline_expressions.BooleanExpression:
+    """
+    Converts a cursor into a filter condition for the pipeline.
+
+    Args:
+        cursor: The cursor values and the 'before' flag.
+        orderings: The list of ordering expressions used in the query.
+        is_start_cursor: True if this is a start_at/start_after cursor, False if it is an end_at/end_before cursor.
+    Returns:
+        A BooleanExpression representing the cursor condition.
+    """
+    cursor_values, before = cursor
+    size = len(cursor_values)
+
+    if is_start_cursor:
+        filter_func = pipeline_expressions.Expression.greater_than
+    else:
+        filter_func = pipeline_expressions.Expression.less_than
+
+    field = orderings[size - 1].expr
+    value = pipeline_expressions.Constant(cursor_values[size - 1])
+
+    # Add condition for last bound
+    condition = filter_func(field, value)
+
+    if (is_start_cursor and before) or (not is_start_cursor and not before):
+        # When the cursor bound is inclusive, then the last bound
+        # can be equal to the value, otherwise it's not equal
+        condition = pipeline_expressions.Or(condition, field.equal(value))
+
+    # Iterate backwards over the remaining bounds, adding a condition for each one
+    for i in range(size - 2, -1, -1):
+        field = orderings[i].expr
+        value = pipeline_expressions.Constant(cursor_values[i])
+
+        # For each field in the orderings, the condition is either
+        # a) lessThan|greaterThan the cursor value,
+        # b) or equal the cursor value and lessThan|greaterThan the cursor values for other fields
+        condition = pipeline_expressions.Or(
+            filter_func(field, value),
+            pipeline_expressions.And(field.equal(value), condition),
+        )
+
+    return condition
+
+
+def _reverse_orderings(
+    orderings: List[pipeline_expressions.Ordering],
+) -> List[pipeline_expressions.Ordering]:
+    reversed_orderings = []
+    for o in orderings:
+        if o.order_dir == pipeline_expressions.Ordering.Direction.ASCENDING:
+            new_dir = "descending"
+        else:
+            new_dir = "ascending"
+        reversed_orderings.append(pipeline_expressions.Ordering(o.expr, new_dir))
+    return reversed_orderings
 
 
 def _query_response_to_snapshot(

--- a/google/cloud/firestore_v1/base_query.py
+++ b/google/cloud/firestore_v1/base_query.py
@@ -1185,10 +1185,10 @@ class BaseQuery(object):
         # Apply cursors as filters.
         if orderings:
             for cursor, is_start in [(self._start_at, True), (self._end_at, False)]:
+                cursor = self._normalize_cursor(cursor, normalized_orders)
                 if cursor:
-                    val = self._normalize_cursor(cursor, normalized_orders)
                     ppl = ppl.where(
-                        _where_conditions_from_cursor(val, orderings, is_start)
+                        _where_conditions_from_cursor(cursor, orderings, is_start)
                     )
 
         # Handle sort and limit, including limit_to_last semantics.

--- a/google/cloud/firestore_v1/pipeline_expressions.py
+++ b/google/cloud/firestore_v1/pipeline_expressions.py
@@ -1833,7 +1833,10 @@ class BooleanExpression(FunctionExpression):
             elif filter_pb.op == Query_pb.FieldFilter.Operator.EQUAL:
                 return And(field.exists(), field.equal(value))
             elif filter_pb.op == Query_pb.FieldFilter.Operator.NOT_EQUAL:
-                return And(field.exists(), field.not_equal(value))
+                # In Enterprise DBs NOT_EQUAL will match a field that does not exist,
+                # therefore we do not want an existence filter for the NOT_EQUAL conversion
+                # so the Query and Pipeline behavior are consistent in Enterprise.
+                return field.not_equal(value)
             if filter_pb.op == Query_pb.FieldFilter.Operator.ARRAY_CONTAINS:
                 return And(field.exists(), field.array_contains(value))
             elif filter_pb.op == Query_pb.FieldFilter.Operator.ARRAY_CONTAINS_ANY:
@@ -1841,7 +1844,10 @@ class BooleanExpression(FunctionExpression):
             elif filter_pb.op == Query_pb.FieldFilter.Operator.IN:
                 return And(field.exists(), field.equal_any(value))
             elif filter_pb.op == Query_pb.FieldFilter.Operator.NOT_IN:
-                return And(field.exists(), field.not_equal_any(value))
+                # In Enterprise DBs NOT_IN will match a field that does not exist,
+                # therefore we do not want an existence filter for the NOT_IN conversion
+                # so the Query and Pipeline behavior are consistent in Enterprise.
+                return field.not_equal_any(value)
             else:
                 raise TypeError(f"Unexpected FieldFilter operator type: {filter_pb.op}")
         elif isinstance(filter_pb, Query_pb.Filter):

--- a/google/cloud/firestore_v1/pipeline_source.py
+++ b/google/cloud/firestore_v1/pipeline_source.py
@@ -57,12 +57,8 @@ class PipelineSource(Generic[PipelineType]):
         """
         Create a pipeline from an existing query
 
-        Queries containing a `cursor` or `limit_to_last` are not currently supported
-
         Args:
             query: the query to build the pipeline off of
-        Raises:
-            - NotImplementedError: raised if the query contains a `cursor` or `limit_to_last`
         Returns:
             a new pipeline instance representing the query
         """

--- a/tests/unit/v1/test_base_query.py
+++ b/tests/unit/v1/test_base_query.py
@@ -2120,7 +2120,9 @@ def test__query_pipeline_cursors():
     from google.cloud.firestore_v1 import pipeline_expressions as expr
 
     client = make_client()
-    query_start = client.collection("my_col").order_by("field_a").start_at({"field_a": 10})
+    query_start = (
+        client.collection("my_col").order_by("field_a").start_at({"field_a": 10})
+    )
     pipeline = query_start._build_pipeline(client.pipeline())
 
     # Stages:
@@ -2129,7 +2131,7 @@ def test__query_pipeline_cursors():
     # 2: Where (cursor condition)
     # 3: Sort (field_a)
     assert len(pipeline.stages) == 4
-    
+
     where_stage = pipeline.stages[2]
     assert isinstance(where_stage, stages.Where)
     # Expected: (field_a > 10) OR (field_a == 10)
@@ -2336,6 +2338,7 @@ def _make_snapshot(docref, values):
 
     return document.DocumentSnapshot(docref, values, True, None, None, None)
 
+
 def test__where_conditions_from_cursor_descending():
     from google.cloud.firestore_v1.base_query import _where_conditions_from_cursor
     from google.cloud.firestore_v1 import pipeline_expressions
@@ -2348,10 +2351,7 @@ def test__where_conditions_from_cursor_descending():
     cursor = ([10], True)
     condition = _where_conditions_from_cursor(cursor, [ordering], is_start_cursor=True)
     # Expected: field < 10 OR field == 10
-    expected = pipeline_expressions.Or(
-        field_expr.less_than(10),
-        field_expr.equal(10)
-    )
+    expected = pipeline_expressions.Or(field_expr.less_than(10), field_expr.equal(10))
     assert condition == expected
 
     # Case 2: StartAfter (exclusive) -> < 10
@@ -2366,8 +2366,7 @@ def test__where_conditions_from_cursor_descending():
     condition = _where_conditions_from_cursor(cursor, [ordering], is_start_cursor=False)
     # Expected: field > 10 OR field == 10
     expected = pipeline_expressions.Or(
-        field_expr.greater_than(10),
-        field_expr.equal(10)
+        field_expr.greater_than(10), field_expr.equal(10)
     )
     assert condition == expected
 


### PR DESCRIPTION
Improves Query to Pipeline logic:
- add support for `cursor` and `limit_to_last`
- apply fewer `exists` clauses, so pipelines give the same results as matching RunQuery statements
