### PR TITLE
chore: remove 3.9 from kokoro tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -85,7 +85,6 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",


### PR DESCRIPTION
3.9 has been removed from the kokoro base image, so we should remove the tests from our configs

3.9 is still tested in GitHub Actions
