### PR TITLE
chore(librarian): update noxfile.py in generator-input

### DIFF
--- a/.librarian/generator-input/noxfile.py
+++ b/.librarian/generator-input/noxfile.py
@@ -67,11 +67,11 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",
     "google-cloud-testutils",
-    
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = [
     "pytest-asyncio==0.21.2",
     "six",
+    "pyyaml",
 ]
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_DEPENDENCIES: List[str] = []

--- a/.librarian/generator-input/noxfile.py
+++ b/.librarian/generator-input/noxfile.py
@@ -67,6 +67,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = [
     "pytest-asyncio==0.21.2",
@@ -80,7 +81,6 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",


### PR DESCRIPTION
This PR applies the patches from https://github.com/googleapis/python-firestore/pull/1156 and https://github.com/googleapis/python-firestore/pull/1163 to the generated noxfile.py under `generator-input` here : https://github.com/googleapis/python-firestore/blob/main/.librarian/generator-input/noxfile.py