### PR TITLE
chore: librarian generate pull request: 20260213T191645Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2,7 +2,7 @@ image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-li
 libraries:
   - id: google-cloud-firestore
     version: 2.23.0
-    last_generated_commit: 1a9d00bed77e6db82ff67764ffe14e3b5209f5cd
+    last_generated_commit: 055f92c9384689eb0bb32d035d3bc6d98c8347c0
     apis:
       - path: google/firestore/v1
         service_config: firestore_v1.yaml

--- a/google/cloud/firestore_admin_v1/services/firestore_admin/async_client.py
+++ b/google/cloud/firestore_admin_v1/services/firestore_admin/async_client.py
@@ -57,6 +57,7 @@ from google.cloud.firestore_admin_v1.types import firestore_admin
 from google.cloud.firestore_admin_v1.types import index
 from google.cloud.firestore_admin_v1.types import index as gfa_index
 from google.cloud.firestore_admin_v1.types import operation as gfa_operation
+from google.cloud.firestore_admin_v1.types import realtime_updates
 from google.cloud.firestore_admin_v1.types import schedule
 from google.cloud.firestore_admin_v1.types import user_creds
 from google.cloud.firestore_admin_v1.types import user_creds as gfa_user_creds
@@ -1721,7 +1722,8 @@ class FirestoreAdminAsyncClient:
                 last a letter or a number. Must not be UUID-like
                 /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/.
 
-                "(default)" database ID is also valid.
+                "(default)" database ID is also valid if the database is
+                Standard edition.
 
                 This corresponds to the ``database_id`` field
                 on the ``request`` instance; if ``request`` is provided, this

--- a/google/cloud/firestore_admin_v1/services/firestore_admin/client.py
+++ b/google/cloud/firestore_admin_v1/services/firestore_admin/client.py
@@ -73,6 +73,7 @@ from google.cloud.firestore_admin_v1.types import firestore_admin
 from google.cloud.firestore_admin_v1.types import index
 from google.cloud.firestore_admin_v1.types import index as gfa_index
 from google.cloud.firestore_admin_v1.types import operation as gfa_operation
+from google.cloud.firestore_admin_v1.types import realtime_updates
 from google.cloud.firestore_admin_v1.types import schedule
 from google.cloud.firestore_admin_v1.types import user_creds
 from google.cloud.firestore_admin_v1.types import user_creds as gfa_user_creds
@@ -2281,7 +2282,8 @@ class FirestoreAdminClient(metaclass=FirestoreAdminClientMeta):
                 last a letter or a number. Must not be UUID-like
                 /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/.
 
-                "(default)" database ID is also valid.
+                "(default)" database ID is also valid if the database is
+                Standard edition.
 
                 This corresponds to the ``database_id`` field
                 on the ``request`` instance; if ``request`` is provided, this

--- a/google/cloud/firestore_admin_v1/types/__init__.py
+++ b/google/cloud/firestore_admin_v1/types/__init__.py
@@ -84,6 +84,9 @@ from .operation import (
     RestoreDatabaseMetadata,
     OperationState,
 )
+from .realtime_updates import (
+    RealtimeUpdatesMode,
+)
 from .schedule import (
     BackupSchedule,
     DailyRecurrence,
@@ -154,6 +157,7 @@ __all__ = (
     "Progress",
     "RestoreDatabaseMetadata",
     "OperationState",
+    "RealtimeUpdatesMode",
     "BackupSchedule",
     "DailyRecurrence",
     "WeeklyRecurrence",

--- a/google/cloud/firestore_admin_v1/types/database.py
+++ b/google/cloud/firestore_admin_v1/types/database.py
@@ -19,6 +19,7 @@ from typing import MutableMapping, MutableSequence
 
 import proto  # type: ignore
 
+from google.cloud.firestore_admin_v1.types import realtime_updates
 from google.protobuf import duration_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 
@@ -68,6 +69,10 @@ class Database(proto.Message):
         concurrency_mode (google.cloud.firestore_admin_v1.types.Database.ConcurrencyMode):
             The concurrency control mode to use for this
             database.
+            If unspecified in a CreateDatabase request, this
+            will default based on the database edition:
+            Optimistic for Enterprise and Pessimistic for
+            all other databases.
         version_retention_period (google.protobuf.duration_pb2.Duration):
             Output only. The period during which past versions of data
             are retained in the database.
@@ -151,6 +156,22 @@ class Database(proto.Message):
             has an up-to-date value before proceeding.
         database_edition (google.cloud.firestore_admin_v1.types.Database.DatabaseEdition):
             Immutable. The edition of the database.
+        realtime_updates_mode (google.cloud.firestore_admin_v1.types.RealtimeUpdatesMode):
+            Immutable. The default Realtime Updates mode
+            to use for this database.
+        firestore_data_access_mode (google.cloud.firestore_admin_v1.types.Database.DataAccessMode):
+            Optional. The Firestore API data access mode to use for this
+            database. If not set on write:
+
+            - the default value is DATA_ACCESS_MODE_DISABLED for
+              Enterprise Edition.
+            - the default value is DATA_ACCESS_MODE_ENABLED for Standard
+              Edition.
+        mongodb_compatible_data_access_mode (google.cloud.firestore_admin_v1.types.Database.DataAccessMode):
+            Optional. The MongoDB compatible API data access mode to use
+            for this database. If not set on write, the default value is
+            DATA_ACCESS_MODE_ENABLED for Enterprise Edition. The value
+            is always DATA_ACCESS_MODE_DISABLED for Standard Edition.
     """
 
     class DatabaseType(proto.Enum):
@@ -183,20 +204,25 @@ class Database(proto.Message):
                 Use optimistic concurrency control by
                 default. This mode is available for Cloud
                 Firestore databases.
+
+                This is the default setting for Cloud Firestore
+                Enterprise Edition databases.
             PESSIMISTIC (2):
                 Use pessimistic concurrency control by
                 default. This mode is available for Cloud
                 Firestore databases.
 
-                This is the default setting for Cloud Firestore.
+                This is the default setting for Cloud Firestore
+                Standard Edition databases.
             OPTIMISTIC_WITH_ENTITY_GROUPS (3):
                 Use optimistic concurrency control with
                 entity groups by default.
-                This is the only available mode for Cloud
-                Datastore.
+                This mode is enabled for some databases that
+                were automatically upgraded from Cloud Datastore
+                to Cloud Firestore with Datastore Mode.
 
-                This mode is also available for Cloud Firestore
-                with Datastore Mode but is not recommended.
+                It is not recommended for any new databases, and
+                not supported for Firestore Native databases.
         """
         CONCURRENCY_MODE_UNSPECIFIED = 0
         OPTIMISTIC = 1
@@ -284,6 +310,23 @@ class Database(proto.Message):
         STANDARD = 1
         ENTERPRISE = 2
 
+    class DataAccessMode(proto.Enum):
+        r"""The data access mode.
+
+        Values:
+            DATA_ACCESS_MODE_UNSPECIFIED (0):
+                Not Used.
+            DATA_ACCESS_MODE_ENABLED (1):
+                Accessing the database through the API is
+                allowed.
+            DATA_ACCESS_MODE_DISABLED (2):
+                Accessing the database through the API is
+                disallowed.
+        """
+        DATA_ACCESS_MODE_UNSPECIFIED = 0
+        DATA_ACCESS_MODE_ENABLED = 1
+        DATA_ACCESS_MODE_DISABLED = 2
+
     class CmekConfig(proto.Message):
         r"""The CMEK (Customer Managed Encryption Key) configuration for
         a Firestore database. If not present, the database is secured by
@@ -369,7 +412,8 @@ class Database(proto.Message):
         r"""Encryption configuration for a new database being created from
         another source.
 
-        The source could be a [Backup][google.firestore.admin.v1.Backup] .
+        The source could be a [Backup][google.firestore.admin.v1.Backup] or
+        a [PitrSnapshot][google.firestore.admin.v1.PitrSnapshot].
 
         This message has `oneof`_ fields (mutually exclusive fields).
         For each oneof, at most one member field can be set at the same time.
@@ -549,6 +593,21 @@ class Database(proto.Message):
         proto.ENUM,
         number=28,
         enum=DatabaseEdition,
+    )
+    realtime_updates_mode: realtime_updates.RealtimeUpdatesMode = proto.Field(
+        proto.ENUM,
+        number=31,
+        enum=realtime_updates.RealtimeUpdatesMode,
+    )
+    firestore_data_access_mode: DataAccessMode = proto.Field(
+        proto.ENUM,
+        number=33,
+        enum=DataAccessMode,
+    )
+    mongodb_compatible_data_access_mode: DataAccessMode = proto.Field(
+        proto.ENUM,
+        number=34,
+        enum=DataAccessMode,
     )
 
 

--- a/google/cloud/firestore_admin_v1/types/field.py
+++ b/google/cloud/firestore_admin_v1/types/field.py
@@ -125,10 +125,13 @@ class Field(proto.Message):
         ``Field`` set.
 
         Storing a timestamp value into a TTL-enabled field will be treated
-        as the document's absolute expiration time. Timestamp values in the
-        past indicate that the document is eligible for immediate
-        expiration. Using any other data type or leaving the field absent
-        will disable expiration for the individual document.
+        as the document's absolute expiration time. For Enterprise edition
+        databases, the timestamp value may also be stored in an array value
+        in the TTL-enabled field.
+
+        Timestamp values in the past indicate that the document is eligible
+        for immediate expiration. Using any other data type or leaving the
+        field absent will disable expiration for the individual document.
 
         Attributes:
             state (google.cloud.firestore_admin_v1.types.Field.TtlConfig.State):

--- a/google/cloud/firestore_admin_v1/types/firestore_admin.py
+++ b/google/cloud/firestore_admin_v1/types/firestore_admin.py
@@ -120,7 +120,8 @@ class CreateDatabaseRequest(proto.Message):
             letter or a number. Must not be UUID-like
             /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/.
 
-            "(default)" database ID is also valid.
+            "(default)" database ID is also valid if the database is
+            Standard edition.
     """
 
     parent: str = proto.Field(
@@ -747,9 +748,9 @@ class ExportDocumentsRequest(proto.Message):
             Required. Database to export. Should be of the form:
             ``projects/{project_id}/databases/{database_id}``.
         collection_ids (MutableSequence[str]):
-            Which collection IDs to export. Unspecified
-            means all collections. Each collection ID in
-            this list must be unique.
+            IDs of the collection groups to export.
+            Unspecified means all collection groups. Each
+            collection group in this list must be unique.
         output_uri_prefix (str):
             The output URI. Currently only supports Google Cloud Storage
             URIs of the form: ``gs://BUCKET_NAME[/NAMESPACE_PATH]``,
@@ -813,9 +814,10 @@ class ImportDocumentsRequest(proto.Message):
             Required. Database to import into. Should be of the form:
             ``projects/{project_id}/databases/{database_id}``.
         collection_ids (MutableSequence[str]):
-            Which collection IDs to import. Unspecified
-            means all collections included in the import.
-            Each collection ID in this list must be unique.
+            IDs of the collection groups to import.
+            Unspecified means all collection groups that
+            were included in the export. Each collection
+            group in this list must be unique.
         input_uri_prefix (str):
             Location of the exported files. This must match the
             output_uri_prefix of an ExportDocumentsResponse from an
@@ -1032,7 +1034,8 @@ class RestoreDatabaseRequest(proto.Message):
             letter or a number. Must not be UUID-like
             /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/.
 
-            "(default)" database ID is also valid.
+            "(default)" database ID is also valid if the database is
+            Standard edition.
         backup (str):
             Required. Backup to restore from. Must be from the same
             project as the parent.
@@ -1100,7 +1103,8 @@ class CloneDatabaseRequest(proto.Message):
             letter or a number. Must not be UUID-like
             /[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}/.
 
-            "(default)" database ID is also valid.
+            "(default)" database ID is also valid if the database is
+            Standard edition.
         pitr_snapshot (google.cloud.firestore_admin_v1.types.PitrSnapshot):
             Required. Specification of the PITR data to
             clone from. The source database must exist.

--- a/google/cloud/firestore_admin_v1/types/realtime_updates.py
+++ b/google/cloud/firestore_admin_v1/types/realtime_updates.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from typing import MutableMapping, MutableSequence
+
+import proto  # type: ignore
+
+
+__protobuf__ = proto.module(
+    package="google.firestore.admin.v1",
+    manifest={
+        "RealtimeUpdatesMode",
+    },
+)
+
+
+class RealtimeUpdatesMode(proto.Enum):
+    r"""The Realtime Updates mode.
+
+    Values:
+        REALTIME_UPDATES_MODE_UNSPECIFIED (0):
+            The Realtime Updates feature is not
+            specified.
+        REALTIME_UPDATES_MODE_ENABLED (1):
+            The Realtime Updates feature is enabled by
+            default.
+            This could potentially degrade write performance
+            for the database.
+        REALTIME_UPDATES_MODE_DISABLED (2):
+            The Realtime Updates feature is disabled by
+            default.
+    """
+    REALTIME_UPDATES_MODE_UNSPECIFIED = 0
+    REALTIME_UPDATES_MODE_ENABLED = 1
+    REALTIME_UPDATES_MODE_DISABLED = 2
+
+
+__all__ = tuple(sorted(__protobuf__.manifest))

--- a/tests/unit/gapic/firestore_admin_v1/test_firestore_admin.py
+++ b/tests/unit/gapic/firestore_admin_v1/test_firestore_admin.py
@@ -74,6 +74,7 @@ from google.cloud.firestore_admin_v1.types import firestore_admin
 from google.cloud.firestore_admin_v1.types import index
 from google.cloud.firestore_admin_v1.types import index as gfa_index
 from google.cloud.firestore_admin_v1.types import operation as gfa_operation
+from google.cloud.firestore_admin_v1.types import realtime_updates
 from google.cloud.firestore_admin_v1.types import schedule
 from google.cloud.firestore_admin_v1.types import snapshot
 from google.cloud.firestore_admin_v1.types import user_creds
@@ -2224,6 +2225,7 @@ def test_get_index(request_type, transport: str = "grpc"):
             density=index.Index.Density.SPARSE_ALL,
             multikey=True,
             shard_count=1178,
+            unique=True,
         )
         response = client.get_index(request)
 
@@ -2242,6 +2244,7 @@ def test_get_index(request_type, transport: str = "grpc"):
     assert response.density == index.Index.Density.SPARSE_ALL
     assert response.multikey is True
     assert response.shard_count == 1178
+    assert response.unique is True
 
 
 def test_get_index_non_empty_request_with_auto_populated_field():
@@ -2372,6 +2375,7 @@ async def test_get_index_async(
                 density=index.Index.Density.SPARSE_ALL,
                 multikey=True,
                 shard_count=1178,
+                unique=True,
             )
         )
         response = await client.get_index(request)
@@ -2391,6 +2395,7 @@ async def test_get_index_async(
     assert response.density == index.Index.Density.SPARSE_ALL
     assert response.multikey is True
     assert response.shard_count == 1178
+    assert response.unique is True
 
 
 @pytest.mark.asyncio
@@ -5401,6 +5406,9 @@ def test_get_database(request_type, transport: str = "grpc"):
             free_tier=True,
             etag="etag_value",
             database_edition=database.Database.DatabaseEdition.STANDARD,
+            realtime_updates_mode=realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED,
+            firestore_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
+            mongodb_compatible_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
         )
         response = client.get_database(request)
 
@@ -5434,6 +5442,18 @@ def test_get_database(request_type, transport: str = "grpc"):
     assert response.free_tier is True
     assert response.etag == "etag_value"
     assert response.database_edition == database.Database.DatabaseEdition.STANDARD
+    assert (
+        response.realtime_updates_mode
+        == realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED
+    )
+    assert (
+        response.firestore_data_access_mode
+        == database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED
+    )
+    assert (
+        response.mongodb_compatible_data_access_mode
+        == database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED
+    )
 
 
 def test_get_database_non_empty_request_with_auto_populated_field():
@@ -5572,6 +5592,9 @@ async def test_get_database_async(
                 free_tier=True,
                 etag="etag_value",
                 database_edition=database.Database.DatabaseEdition.STANDARD,
+                realtime_updates_mode=realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED,
+                firestore_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
+                mongodb_compatible_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
             )
         )
         response = await client.get_database(request)
@@ -5606,6 +5629,18 @@ async def test_get_database_async(
     assert response.free_tier is True
     assert response.etag == "etag_value"
     assert response.database_edition == database.Database.DatabaseEdition.STANDARD
+    assert (
+        response.realtime_updates_mode
+        == realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED
+    )
+    assert (
+        response.firestore_data_access_mode
+        == database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED
+    )
+    assert (
+        response.mongodb_compatible_data_access_mode
+        == database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED
+    )
 
 
 @pytest.mark.asyncio
@@ -19094,6 +19129,7 @@ async def test_get_index_empty_call_grpc_asyncio():
                 density=index.Index.Density.SPARSE_ALL,
                 multikey=True,
                 shard_count=1178,
+                unique=True,
             )
         )
         await client.get_index(request=None)
@@ -19337,6 +19373,9 @@ async def test_get_database_empty_call_grpc_asyncio():
                 free_tier=True,
                 etag="etag_value",
                 database_edition=database.Database.DatabaseEdition.STANDARD,
+                realtime_updates_mode=realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED,
+                firestore_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
+                mongodb_compatible_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
             )
         )
         await client.get_database(request=None)
@@ -20034,6 +20073,7 @@ def test_create_index_rest_call_success(request_type):
         "density": 1,
         "multikey": True,
         "shard_count": 1178,
+        "unique": True,
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -20374,6 +20414,7 @@ def test_get_index_rest_call_success(request_type):
             density=index.Index.Density.SPARSE_ALL,
             multikey=True,
             shard_count=1178,
+            unique=True,
         )
 
         # Wrap the value into a proper Response obj
@@ -20397,6 +20438,7 @@ def test_get_index_rest_call_success(request_type):
     assert response.density == index.Index.Density.SPARSE_ALL
     assert response.multikey is True
     assert response.shard_count == 1178
+    assert response.unique is True
 
 
 @pytest.mark.parametrize("null_interceptor", [True, False])
@@ -20766,6 +20808,7 @@ def test_update_field_rest_call_success(request_type):
                     "density": 1,
                     "multikey": True,
                     "shard_count": 1178,
+                    "unique": True,
                 }
             ],
             "uses_ancestor_config": True,
@@ -21496,6 +21539,9 @@ def test_create_database_rest_call_success(request_type):
         "free_tier": True,
         "etag": "etag_value",
         "database_edition": 1,
+        "realtime_updates_mode": 1,
+        "firestore_data_access_mode": 1,
+        "mongodb_compatible_data_access_mode": 1,
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency
@@ -21704,6 +21750,9 @@ def test_get_database_rest_call_success(request_type):
             free_tier=True,
             etag="etag_value",
             database_edition=database.Database.DatabaseEdition.STANDARD,
+            realtime_updates_mode=realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED,
+            firestore_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
+            mongodb_compatible_data_access_mode=database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED,
         )
 
         # Wrap the value into a proper Response obj
@@ -21742,6 +21791,18 @@ def test_get_database_rest_call_success(request_type):
     assert response.free_tier is True
     assert response.etag == "etag_value"
     assert response.database_edition == database.Database.DatabaseEdition.STANDARD
+    assert (
+        response.realtime_updates_mode
+        == realtime_updates.RealtimeUpdatesMode.REALTIME_UPDATES_MODE_ENABLED
+    )
+    assert (
+        response.firestore_data_access_mode
+        == database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED
+    )
+    assert (
+        response.mongodb_compatible_data_access_mode
+        == database.Database.DataAccessMode.DATA_ACCESS_MODE_ENABLED
+    )
 
 
 @pytest.mark.parametrize("null_interceptor", [True, False])
@@ -22008,6 +22069,9 @@ def test_update_database_rest_call_success(request_type):
         "free_tier": True,
         "etag": "etag_value",
         "database_edition": 1,
+        "realtime_updates_mode": 1,
+        "firestore_data_access_mode": 1,
+        "mongodb_compatible_data_access_mode": 1,
     }
     # The version of a generated dependency at test runtime may differ from the version used during generation.
     # Delete any fields which are not present in the current runtime dependency


### PR DESCRIPTION
PR created by the Librarian CLI to generate Cloud Client Libraries code from protos.

BEGIN_COMMIT

BEGIN_NESTED_COMMIT
feat: Expose the `Database.firestore_data_access_mode` parameter


PiperOrigin-RevId: 865444806
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@760ef858](https://github.com/googleapis/googleapis/commit/760ef858)
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
feat: Expose the `Database.mongodb_compatible_data_access_mode` parameter


PiperOrigin-RevId: 865444806
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@760ef858](https://github.com/googleapis/googleapis/commit/760ef858)
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
feat: Expose the `Database.realtime_updates_mode` parameter


PiperOrigin-RevId: 865444806
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@760ef858](https://github.com/googleapis/googleapis/commit/760ef858)
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
feat: Expose the `Index.unique` parameter


PiperOrigin-RevId: 865444806
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@760ef858](https://github.com/googleapis/googleapis/commit/760ef858)
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
docs: Update documentation on several parameters, especially when relating to the new `enterprise` database edition


PiperOrigin-RevId: 865444806
Library-IDs: google-cloud-firestore
Source-link: [googleapis/googleapis@760ef858](https://github.com/googleapis/googleapis/commit/760ef858)
END_NESTED_COMMIT

END_COMMIT

This pull request is generated with proto changes between
[googleapis/googleapis@1a9d00be](https://github.com/googleapis/googleapis/commit/1a9d00bed77e6db82ff67764ffe14e3b5209f5cd)
(exclusive) and
[googleapis/googleapis@760ef858](https://github.com/googleapis/googleapis/commit/760ef85838a9f9decef98fcb91e2a73891ed8f7d)
(inclusive).

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209